### PR TITLE
[SAC-27686] [SAC-27687] - Libraries upgrade, Tap-framework replacement, Backoff implementation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,35 @@
+version: 2.1
+
+executors:
+  docker-executor:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+
+jobs:
+  build:
+    executor: docker-executor
+    steps:
+      - checkout
+      - run:
+          name: 'Setup'
+          command: |
+            python3 -m venv /usr/local/share/virtualenvs/tap-campaign-monitor
+            source /usr/local/share/virtualenvs/tap-campaign-monitor/bin/activate
+            pip install -U 'pip==22.2.2' setuptools
+            pip install .[dev]
+      - run:
+          name: 'Pylint'
+          command: |
+            source /usr/local/share/virtualenvs/tap-campaign-monitor/bin/activate
+            pylint tap_campaign_monitor -d C,R,W
+      - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-campaign-monitor/bin/activate
+            nosetests tests
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build:
+          context: circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,11 @@ jobs:
             pip install -U 'pip==22.2.2' setuptools
             pip install .[dev]
       - run:
+          name: 'JSON Validator'
+          command: |
+            source /usr/local/share/virtualenvs/tap-campaign-monitor/bin/activate
+            stitch-validate-json tap_campaign_monitor/schemas/*.json
+      - run:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-campaign-monitor/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,6 @@ jobs:
             pip install -U 'pip==22.2.2' setuptools
             pip install .[dev]
       - run:
-          name: 'Pylint'
-          command: |
-            source /usr/local/share/virtualenvs/tap-campaign-monitor/bin/activate
-            pylint tap_campaign_monitor -d C,R,W
-      - run:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-campaign-monitor/bin/activate

--- a/config.example.json
+++ b/config.example.json
@@ -1,4 +1,4 @@
 {
-	"api_key": "",
+	"refresh_token": "",
 	"client_id": ""
 }

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,9 @@ setup(
     url='https://www.stitchdata.com',
     classifiers=['Programming Language :: Python :: 3 :: Only'],
     install_requires=[
-        'tap-framework==0.0.5'
+        'singer-python==6.1.1',
+        'backoff==2.2.1',
+        'requests==2.32.3',
     ],
     entry_points='''
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,11 @@ setup(
         'backoff==2.2.1',
         'requests==2.32.3',
     ],
+    extras_require = {
+      "dev": [
+        "nose",
+      ],
+    },
     entry_points='''
         [console_scripts]
         tap-campaign-monitor=tap_campaign_monitor:main

--- a/tap_campaign_monitor/__init__.py
+++ b/tap_campaign_monitor/__init__.py
@@ -6,11 +6,11 @@ import sys
 
 import singer
 
-from tap_framework.streams import is_selected
 
 from tap_campaign_monitor.client import CampaignMonitorClient
 from tap_campaign_monitor.state import save_state
 from tap_campaign_monitor.streams import AVAILABLE_STREAMS
+from tap_campaign_monitor.streams.base import is_selected   
 
 LOGGER = singer.get_logger()  # noqa
 

--- a/tap_campaign_monitor/__init__.py
+++ b/tap_campaign_monitor/__init__.py
@@ -10,7 +10,7 @@ import singer
 from tap_campaign_monitor.client import CampaignMonitorClient
 from tap_campaign_monitor.state import save_state
 from tap_campaign_monitor.streams import AVAILABLE_STREAMS
-from tap_campaign_monitor.streams.base import is_selected   
+from tap_campaign_monitor.streams.base import is_stream_selected
 
 LOGGER = singer.get_logger()  # noqa
 
@@ -37,7 +37,7 @@ def get_streams_to_replicate(config, state, catalog, client):
         return streams, campaign_substreams, list_substreams
 
     for stream_catalog in catalog.streams:
-        if not is_selected(stream_catalog):
+        if not is_stream_selected(stream_catalog):
             LOGGER.info("'{}' is not marked selected, skipping."
                         .format(stream_catalog.stream))
             continue

--- a/tap_campaign_monitor/client.py
+++ b/tap_campaign_monitor/client.py
@@ -49,12 +49,22 @@ class CampaignMonitorClient:
 
     @backoff.on_exception(
         backoff.expo,
-        (ConnectionError, Server5xxError, Server429Error),
+        Server429Error,
+        max_tries=7,
+        factor=4,  # longer wait
+        on_backoff=lambda details: LOGGER.warning(
+            f"[RateLimit] Retrying {details['target'].__name__}, attempt {details['tries']}, "
+            f"waiting {details['wait']:0.1f}s due to {repr(details['exception'])}"
+        )
+    )
+    @backoff.on_exception(
+        backoff.expo,
+        (ConnectionError, Server5xxError),
         max_tries=5,
         factor=2,
         on_backoff=lambda details: LOGGER.warning(
-            f"Retrying {details['target'].__name__}, attempt {details['tries']}, "
-            f"waiting {details['wait']:0.1f}s, after {repr(details['exception'])}"
+            f"[Retryable] Retrying {details['target'].__name__}, attempt {details['tries']}, "
+            f"waiting {details['wait']:0.1f}s due to {repr(details['exception'])}"
         )
     )
     def make_request(self, url, method, params=None, body=None):

--- a/tap_campaign_monitor/client.py
+++ b/tap_campaign_monitor/client.py
@@ -26,6 +26,8 @@ class CampaignMonitorClient:
         self.config = config
         self.access_token = self.refresh_access_token()
         self.timezone = self.get_timezone()
+        self.calls_remaining = None
+        self.limit_reset = None
         LOGGER.info("Client timezone is {}".format(self.timezone))
 
     def refresh_access_token(self):
@@ -50,8 +52,8 @@ class CampaignMonitorClient:
     @backoff.on_exception(
         backoff.expo,
         Server429Error,
-        max_tries=7,
-        factor=4,  # longer wait
+        max_tries=5,
+        factor=2,
         on_backoff=lambda details: LOGGER.warning(
             f"[RateLimit] Retrying {details['target'].__name__}, attempt {details['tries']}, "
             f"waiting {details['wait']:0.1f}s due to {repr(details['exception'])}"
@@ -70,6 +72,11 @@ class CampaignMonitorClient:
     def make_request(self, url, method, params=None, body=None):
         LOGGER.info("Making {} request to {}".format(method, url))
 
+        if self.calls_remaining is not None and self.calls_remaining == 0:
+            wait = self.limit_reset - int(time.monotonic())
+            if 0 < wait <= 300:
+                time.sleep(wait)
+
         response = requests.request(
             method,
             url,
@@ -79,6 +86,9 @@ class CampaignMonitorClient:
             },
             params=params,
             json=body)
+
+        self.calls_remaining = int(response.headers['X-Ratelimit-Remaining'])
+        self.limit_reset = int(float(response.headers['X-Ratelimit-Reset']))
 
         if response.status_code >= 500  and response.status_code < 600:
             raise Server5xxError()

--- a/tap_campaign_monitor/client.py
+++ b/tap_campaign_monitor/client.py
@@ -1,5 +1,7 @@
+import backoff
 import requests
 import requests.auth
+from requests.exceptions import ConnectionError
 import singer
 import singer.metrics
 import time
@@ -10,11 +12,19 @@ import tap_campaign_monitor.timezones
 LOGGER = singer.get_logger()  # noqa
 
 
+class Server5xxError(Exception):
+    pass
+
+
+class Server429Error(Exception):
+    pass
+
+
 class CampaignMonitorClient:
 
     def __init__(self, config):
         self.config = config
-        self.refresh_access_token()
+        self.access_token = self.refresh_access_token()
         self.timezone = self.get_timezone()
         LOGGER.info("Client timezone is {}".format(self.timezone))
 
@@ -23,7 +33,7 @@ class CampaignMonitorClient:
         url = "https://api.createsend.com/oauth/token"
         data = {'grant_type': 'refresh_token', 'refresh_token': self.config['refresh_token']}
         response = requests.request("POST", url, data=data)
-        self.access_token = response.json()['access_token']
+        return response.json()['access_token']
 
     def get_timezone(self):
         url = (
@@ -37,9 +47,17 @@ class CampaignMonitorClient:
 
         return tap_campaign_monitor.timezones.from_string(timezone)
 
-    def make_request(self, url, method, base_backoff=30,
-                     params=None, body=None):
-
+    @backoff.on_exception(
+        backoff.expo,
+        (ConnectionError, Server5xxError, Server429Error),
+        max_tries=5,
+        factor=2,
+        on_backoff=lambda details: LOGGER.warning(
+            f"Retrying {details['target'].__name__}, attempt {details['tries']}, "
+            f"waiting {details['wait']:0.1f}s, after {repr(details['exception'])}"
+        )
+    )
+    def make_request(self, url, method, params=None, body=None):
         LOGGER.info("Making {} request to {}".format(method, url))
 
         response = requests.request(
@@ -52,18 +70,10 @@ class CampaignMonitorClient:
             params=params,
             json=body)
 
-        if response.status_code in [429, 504]:
-            if base_backoff > 120:
-                raise RuntimeError('Backed off too many times, exiting!')
-
-            LOGGER.warn('Sleeping for {} seconds and trying again'
-                        .format(base_backoff))
-
-            time.sleep(base_backoff)
-
-            return self.make_request(
-                url, method, base_backoff * 2, params, body)
-
+        if response.status_code >= 500:
+            raise Server5xxError()
+        elif response.status_code == 429:
+            raise Server429Error()
         elif response.status_code != 200:
             raise RuntimeError(response.text)
 

--- a/tap_campaign_monitor/client.py
+++ b/tap_campaign_monitor/client.py
@@ -70,7 +70,7 @@ class CampaignMonitorClient:
             params=params,
             json=body)
 
-        if response.status_code >= 500:
+        if response.status_code >= 500  and response.status_code < 600:
             raise Server5xxError()
         elif response.status_code == 429:
             raise Server429Error()

--- a/tap_campaign_monitor/client.py
+++ b/tap_campaign_monitor/client.py
@@ -9,6 +9,8 @@ import pytz
 
 import tap_campaign_monitor.timezones
 
+RETRY_RATE_LIMIT = 360
+
 LOGGER = singer.get_logger()  # noqa
 
 
@@ -87,9 +89,9 @@ class CampaignMonitorClient:
             raise Server5xxError()
         elif response.status_code == 429:
             try:
-                retry_after = int(float(response.headers.get("X-RateLimit-Reset", 360)))
+                retry_after = int(float(response.headers.get("X-RateLimit-Reset", RETRY_RATE_LIMIT)))
             except (TypeError, ValueError):
-                retry_after = None
+                retry_after = RETRY_RATE_LIMIT
             raise Server429Error(retry_after=retry_after)
         elif response.status_code != 200:
             raise RuntimeError(response.text)

--- a/tap_campaign_monitor/client.py
+++ b/tap_campaign_monitor/client.py
@@ -22,7 +22,6 @@ class Server429Error(Exception):
     pass
 
 
-
 class CampaignMonitorClient:
 
     def __init__(self, config):

--- a/tap_campaign_monitor/client.py
+++ b/tap_campaign_monitor/client.py
@@ -9,7 +9,7 @@ import pytz
 
 import tap_campaign_monitor.timezones
 
-RETRY_RATE_LIMIT = 4
+RETRY_RATE_LIMIT = 360
 
 LOGGER = singer.get_logger()  # noqa
 

--- a/tap_campaign_monitor/client.py
+++ b/tap_campaign_monitor/client.py
@@ -9,7 +9,7 @@ import pytz
 
 import tap_campaign_monitor.timezones
 
-RETRY_RATE_LIMIT = 360
+RETRY_RATE_LIMIT = 4
 
 LOGGER = singer.get_logger()  # noqa
 
@@ -19,9 +19,8 @@ class Server5xxError(Exception):
 
 
 class Server429Error(Exception):
-    def __init__(self, message=None, retry_after=None):
-        super().__init__(message)
-        self.retry_after = retry_after
+    pass
+
 
 
 class CampaignMonitorClient:
@@ -30,6 +29,7 @@ class CampaignMonitorClient:
         self.config = config
         self.access_token = self.refresh_access_token()
         self.timezone = self.get_timezone()
+        self._retry_after = RETRY_RATE_LIMIT
         LOGGER.info("Client timezone is {}".format(self.timezone))
 
     def refresh_access_token(self):
@@ -50,50 +50,62 @@ class CampaignMonitorClient:
         timezone = result.get('BasicDetails', {}).get('TimeZone')
 
         return tap_campaign_monitor.timezones.from_string(timezone)
+    def _rate_limit_backoff(self):
+        """
+        Bound wait‐generator: on each retry backoff will call next()
+        and sleep for self._retry_after seconds.
+        """
+        while True:
+            yield self._retry_after
 
-    @backoff.on_exception(
-        backoff.constant,
-        Server429Error,
-        max_tries=5,
-        on_backoff=lambda details: (
-            LOGGER.warning(
-                f"[RateLimit] Retrying {details['target'].__name__}, attempt {details['tries']}, "
-                f"waiting {details['exception'].retry_after or 0}s due to rate limit {repr(details['exception'])}"
-            ),
-            sleep(details['exception'].retry_after or 0)
-        ),
-    )
-    @backoff.on_exception(
-        backoff.expo,
-        (ConnectionError, Server5xxError),
-        max_tries=5,
-        on_backoff=lambda details: LOGGER.warning(
-            f"[Retryable] Retrying {details['target'].__name__}, attempt {details['tries']}, "
-            f"waiting {details['wait']:0.1f}s due to {repr(details['exception'])}"
-        )
-    )
     def make_request(self, url, method, params=None, body=None):
-        LOGGER.info("Making {} request to {}".format(method, url))
+        @backoff.on_exception(
+            self._rate_limit_backoff,
+            Server429Error,
+            max_tries=5,
+            jitter=None,
+            on_backoff=lambda details: LOGGER.warning(
+                f"[RateLimit] Retrying {details['target'].__name__}, attempt {details['tries']}, "
+                f"waiting {details['wait']:0.1f}s due to {repr(details['exception'])}"
+            ),
+        )
+        @backoff.on_exception(
+            backoff.expo,
+            (ConnectionError, Server5xxError),
+            max_tries=5,
+            on_backoff=lambda details: LOGGER.warning(
+                f"[Retryable] Retrying {details['target'].__name__}, attempt {details['tries']}, "
+                f"waiting {details['wait']:0.1f}s due to {repr(details['exception'])}"
+            ),
+        )
+        def _call():
+            LOGGER.info("Making {} request to {}".format(method, url))
 
-        response = requests.request(
-            method,
-            url,
-            headers={
-                'Content-Type': 'application/json',
-                'Authorization': "Bearer {}".format(self.access_token)
-            },
-            params=params,
-            json=body)
+            resp = requests.request(
+                method,
+                url,
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": "Bearer {}".format(self.access_token),
+                },
+                params=params,
+                json=body,
+            )
 
-        if response.status_code >= 500  and response.status_code < 600:
-            raise Server5xxError()
-        elif response.status_code == 429:
-            try:
-                retry_after = int(float(response.headers.get("X-RateLimit-Reset", RETRY_RATE_LIMIT)))
-            except (TypeError, ValueError):
-                retry_after = RETRY_RATE_LIMIT
-            raise Server429Error(retry_after=retry_after)
-        elif response.status_code != 200:
-            raise RuntimeError(response.text)
+            if resp.status_code >= 500 and resp.status_code < 600:
+                raise Server5xxError()
+            elif resp.status_code == 429:
+                try:
+                    self._retry_after = int(
+                        float(resp.headers.get("X-RateLimit-Reset", RETRY_RATE_LIMIT))
+                    )
+                except (TypeError, ValueError):
+                    self._retry_after = RETRY_RATE_LIMIT
+                raise Server429Error()
+            elif resp.status_code != 200:
+                raise RuntimeError(resp.text)
 
+            return resp
+
+        response = _call()
         return response.json()

--- a/tap_campaign_monitor/client.py
+++ b/tap_campaign_monitor/client.py
@@ -28,8 +28,6 @@ class CampaignMonitorClient:
         self.config = config
         self.access_token = self.refresh_access_token()
         self.timezone = self.get_timezone()
-        self.calls_remaining = None
-        self.limit_reset = None
         LOGGER.info("Client timezone is {}".format(self.timezone))
 
     def refresh_access_token(self):

--- a/tap_campaign_monitor/client.py
+++ b/tap_campaign_monitor/client.py
@@ -4,7 +4,7 @@ import requests.auth
 from requests.exceptions import ConnectionError
 import singer
 import singer.metrics
-from time import sleep
+import time
 import pytz
 
 import tap_campaign_monitor.timezones

--- a/tap_campaign_monitor/client.py
+++ b/tap_campaign_monitor/client.py
@@ -26,9 +26,9 @@ class CampaignMonitorClient:
 
     def __init__(self, config):
         self.config = config
+        self._retry_after = RETRY_RATE_LIMIT
         self.access_token = self.refresh_access_token()
         self.timezone = self.get_timezone()
-        self._retry_after = RETRY_RATE_LIMIT
         LOGGER.info("Client timezone is {}".format(self.timezone))
 
     def refresh_access_token(self):

--- a/tap_campaign_monitor/client.py
+++ b/tap_campaign_monitor/client.py
@@ -4,7 +4,7 @@ import requests.auth
 from requests.exceptions import ConnectionError
 import singer
 import singer.metrics
-import time
+from time import sleep
 import pytz
 
 import tap_campaign_monitor.timezones
@@ -17,7 +17,9 @@ class Server5xxError(Exception):
 
 
 class Server429Error(Exception):
-    pass
+    def __init__(self, message=None, retry_after=None):
+        super().__init__(message)
+        self.retry_after = retry_after
 
 
 class CampaignMonitorClient:
@@ -50,20 +52,21 @@ class CampaignMonitorClient:
         return tap_campaign_monitor.timezones.from_string(timezone)
 
     @backoff.on_exception(
-        backoff.expo,
+        backoff.constant,
         Server429Error,
         max_tries=5,
-        factor=2,
-        on_backoff=lambda details: LOGGER.warning(
-            f"[RateLimit] Retrying {details['target'].__name__}, attempt {details['tries']}, "
-            f"waiting {details['wait']:0.1f}s due to {repr(details['exception'])}"
-        )
+        on_backoff=lambda details: (
+            LOGGER.warning(
+                f"[RateLimit] Retrying {details['target'].__name__}, attempt {details['tries']}, "
+                f"waiting {details['exception'].retry_after or 0}s due to rate limit {repr(details['exception'])}"
+            ),
+            sleep(details['exception'].retry_after or 0)
+        ),
     )
     @backoff.on_exception(
         backoff.expo,
         (ConnectionError, Server5xxError),
         max_tries=5,
-        factor=2,
         on_backoff=lambda details: LOGGER.warning(
             f"[Retryable] Retrying {details['target'].__name__}, attempt {details['tries']}, "
             f"waiting {details['wait']:0.1f}s due to {repr(details['exception'])}"
@@ -71,11 +74,6 @@ class CampaignMonitorClient:
     )
     def make_request(self, url, method, params=None, body=None):
         LOGGER.info("Making {} request to {}".format(method, url))
-
-        if self.calls_remaining is not None and self.calls_remaining == 0:
-            wait = self.limit_reset - int(time.monotonic())
-            if 0 < wait <= 300:
-                time.sleep(wait)
 
         response = requests.request(
             method,
@@ -87,13 +85,14 @@ class CampaignMonitorClient:
             params=params,
             json=body)
 
-        self.calls_remaining = int(response.headers['X-Ratelimit-Remaining'])
-        self.limit_reset = int(float(response.headers['X-Ratelimit-Reset']))
-
         if response.status_code >= 500  and response.status_code < 600:
             raise Server5xxError()
         elif response.status_code == 429:
-            raise Server429Error()
+            try:
+                retry_after = int(float(response.headers.get("X-RateLimit-Reset", 360)))
+            except (TypeError, ValueError):
+                retry_after = None
+            raise Server429Error(retry_after=retry_after)
         elif response.status_code != 200:
             raise RuntimeError(response.text)
 

--- a/tap_campaign_monitor/client.py
+++ b/tap_campaign_monitor/client.py
@@ -49,6 +49,7 @@ class CampaignMonitorClient:
         timezone = result.get('BasicDetails', {}).get('TimeZone')
 
         return tap_campaign_monitor.timezones.from_string(timezone)
+
     def _rate_limit_backoff(self):
         """
         Bound wait‐generator: on each retry backoff will call next()
@@ -63,19 +64,11 @@ class CampaignMonitorClient:
             Server429Error,
             max_tries=5,
             jitter=None,
-            on_backoff=lambda details: LOGGER.warning(
-                f"[RateLimit] Retrying {details['target'].__name__}, attempt {details['tries']}, "
-                f"waiting {details['wait']:0.1f}s due to {repr(details['exception'])}"
-            ),
         )
         @backoff.on_exception(
             backoff.expo,
             (ConnectionError, Server5xxError),
             max_tries=5,
-            on_backoff=lambda details: LOGGER.warning(
-                f"[Retryable] Retrying {details['target'].__name__}, attempt {details['tries']}, "
-                f"waiting {details['wait']:0.1f}s due to {repr(details['exception'])}"
-            ),
         )
         def _call():
             LOGGER.info("Making {} request to {}".format(method, url))

--- a/tap_campaign_monitor/streams/base.py
+++ b/tap_campaign_monitor/streams/base.py
@@ -123,9 +123,9 @@ class BaseStream:
 
     def generate_catalog(self):
         schema = self.get_schema()
-        mdata = singer.metadata.new()
+        mdata = meta.new()
 
-        mdata = singer.metadata.write(
+        mdata = meta.write(
             mdata,
             (),
             'inclusion',
@@ -138,7 +138,7 @@ class BaseStream:
             if field_name in self.KEY_PROPERTIES:
                 inclusion = 'automatic'
 
-            mdata = singer.metadata.write(
+            mdata = meta.write(
                 mdata,
                 ('properties', field_name),
                 'inclusion',
@@ -150,7 +150,7 @@ class BaseStream:
             'stream': self.TABLE,
             'key_properties': self.KEY_PROPERTIES,
             'schema': self.get_schema(),
-            'metadata': singer.metadata.to_list(mdata)
+            'metadata': meta.to_list(mdata)
         }]
 
     def write_schema(self):
@@ -164,7 +164,7 @@ class BaseStream:
             metadata = {}
 
             if self.catalog.metadata is not None:
-                metadata = singer.metadata.to_map(self.catalog.metadata)
+                metadata = meta.to_map(self.catalog.metadata)
 
             return tx.transform(
                 record,

--- a/tap_campaign_monitor/streams/base.py
+++ b/tap_campaign_monitor/streams/base.py
@@ -1,7 +1,9 @@
+import inspect
 import singer
 import singer.utils
 import singer.metrics
 import dateutil.parser
+import os
 import pytz
 
 from singer.transform import Transformer, VALID_DATETIME_FORMATS, \
@@ -9,7 +11,6 @@ from singer.transform import Transformer, VALID_DATETIME_FORMATS, \
     unix_seconds_to_datetime, unix_milliseconds_to_datetime
 from singer.utils import strftime
 
-from tap_framework.streams import BaseStream as base
 from tap_campaign_monitor.state import incorporate, save_state, \
     get_last_record_value_for_table
 
@@ -34,6 +35,26 @@ def string_to_datetime(value, timezone):
         LOGGER.exception(ex)
         LOGGER.warning("%s, (%s)", ex, value)
         return None
+
+
+def is_selected(stream_catalog):
+    metadata = singer.metadata.to_map(stream_catalog.metadata)
+    stream_metadata = metadata.get((), {})
+
+    inclusion = stream_metadata.get('inclusion')
+
+    if stream_metadata.get('selected') is not None:
+        selected = stream_metadata.get('selected')
+    else:
+        selected = stream_metadata.get('selected-by-default')
+
+    if inclusion == 'unsupported':
+        return False
+
+    elif selected is not None:
+        return selected
+
+    return inclusion == 'automatic'
 
 
 class CampaignMonitorTransformer(Transformer):
@@ -61,9 +82,143 @@ class CampaignMonitorTransformer(Transformer):
                 return string_to_datetime(value, self.timezone)
 
 
-class BaseStream(base):
+class BaseStream:
     KEY_PROPERTIES = ['id']
     API_METHOD = 'GET'
+    TABLE = None
+    REQUIRES = []
+
+    def __init__(self, config, state, catalog, client):
+        self.config = config
+        self.state = state
+        self.catalog = catalog
+        self.client = client
+        self.substreams = []
+
+    def get_class_path(self):
+        return os.path.dirname(inspect.getfile(self.__class__))
+
+    def load_schema_by_name(self, name):
+        return singer.utils.load_json(
+            os.path.normpath(
+                os.path.join(
+                    self.get_class_path(),
+                    '../schemas/{}.json'.format(name))))
+
+    def get_schema(self):
+        return self.load_schema_by_name(self.TABLE)
+
+    def get_stream_data(self, result):
+        """
+        Given a result set from Campaign Monitor, return the data
+        to be persisted for this stream.
+        """
+        raise RuntimeError("get_stream_data not implemented!")
+
+    def get_url(self):
+        """
+        Return the URL to hit for data from this stream.
+        """
+        raise RuntimeError("get_url not implemented!")
+
+    @classmethod
+    def requirements_met(cls, catalog):
+        selected_streams = [
+            s.stream for s in catalog.streams if is_selected(s)
+        ]
+
+        return set(cls.REQUIRES).issubset(selected_streams)
+
+    @classmethod
+    def matches_catalog(cls, stream_catalog):
+        return stream_catalog.stream == cls.TABLE
+
+    def generate_catalog(self):
+        schema = self.get_schema()
+        mdata = singer.metadata.new()
+
+        mdata = singer.metadata.write(
+            mdata,
+            (),
+            'inclusion',
+            'available'
+        )
+
+        for field_name, field_schema in schema.get('properties').items():
+            inclusion = 'available'
+
+            if field_name in self.KEY_PROPERTIES:
+                inclusion = 'automatic'
+
+            mdata = singer.metadata.write(
+                mdata,
+                ('properties', field_name),
+                'inclusion',
+                inclusion
+            )
+
+        return [{
+            'tap_stream_id': self.TABLE,
+            'stream': self.TABLE,
+            'key_properties': self.KEY_PROPERTIES,
+            'schema': self.get_schema(),
+            'metadata': singer.metadata.to_list(mdata)
+        }]
+
+    def transform_record(self, record):
+        with singer.Transformer() as tx:
+            metadata = {}
+
+            if self.catalog.metadata is not None:
+                metadata = singer.metadata.to_map(self.catalog.metadata)
+
+            return tx.transform(
+                record,
+                self.catalog.schema.to_dict(),
+                metadata)
+
+    def get_catalog_keys(self):
+        return list(self.catalog.schema.properties.keys())
+
+    def write_schema(self):
+        singer.write_schema(
+            self.catalog.stream,
+            self.catalog.schema.to_dict(),
+            key_properties=self.catalog.key_properties)
+
+    def sync(self):
+        LOGGER.info('Syncing stream {} with {}'
+                    .format(self.catalog.tap_stream_id,
+                            self.__class__.__name__))
+
+        self.write_schema()
+
+        return self.sync_data()
+
+    def sync_data(self, substreams=None):
+        if substreams is None:
+            substreams = []
+
+        table = self.TABLE
+
+        url = self.get_url()
+
+        result = self.client.make_request(url, self.API_METHOD)
+
+        data = self.get_stream_data(result)
+
+        with singer.metrics.record_counter(endpoint=table) as counter:
+            for index, obj in enumerate(data):
+                LOGGER.debug("On {} of {}".format(index, len(data)))
+
+                singer.write_records(
+                    table,
+                    [self.transform_record(obj)])
+
+                counter.increment()
+
+                for substream in substreams:
+                    substream.sync_data(parent=obj)
 
     def transform_record(self, record):
         with CampaignMonitorTransformer(self.client.timezone) as tx:

--- a/tap_campaign_monitor/streams/base.py
+++ b/tap_campaign_monitor/streams/base.py
@@ -115,12 +115,6 @@ class BaseStream:
         """
         raise RuntimeError("get_stream_data not implemented!")
 
-    def get_url(self):
-        """
-        Return the URL to hit for data from this stream.
-        """
-        raise RuntimeError("get_url not implemented!")
-
     @classmethod
     def requirements_met(cls, catalog):
         selected_streams = [
@@ -164,9 +158,6 @@ class BaseStream:
             'schema': self.get_schema(),
             'metadata': singer.metadata.to_list(mdata)
         }]
-
-    def get_catalog_keys(self):
-        return list(self.catalog.schema.properties.keys())
 
     def write_schema(self):
         singer.write_schema(

--- a/tap_campaign_monitor/streams/base.py
+++ b/tap_campaign_monitor/streams/base.py
@@ -6,6 +6,7 @@ import dateutil.parser
 import os
 import pytz
 
+from singer import metadata as meta
 from singer.transform import Transformer, VALID_DATETIME_FORMATS, \
     NO_INTEGER_DATETIME_PARSING, UNIX_SECONDS_INTEGER_DATETIME_PARSING, \
     unix_seconds_to_datetime, unix_milliseconds_to_datetime
@@ -37,21 +38,14 @@ def string_to_datetime(value, timezone):
         return None
 
 
-def is_selected(stream_catalog):
-    metadata = singer.metadata.to_map(stream_catalog.metadata)
-    stream_metadata = metadata.get((), {})
+def is_stream_selected(stream):
+    stream_metadata = meta.to_map(stream.metadata)
 
-    inclusion = stream_metadata.get('inclusion')
-
-    if stream_metadata.get('selected') is not None:
-        selected = stream_metadata.get('selected')
-    else:
-        selected = stream_metadata.get('selected-by-default')
-
+    selected = meta.get(stream_metadata, (), 'selected')
+    inclusion = meta.get(stream_metadata, (), 'inclusion')
     if inclusion == 'unsupported':
         return False
-
-    elif selected is not None:
+    if selected is not None:
         return selected
 
     return inclusion == 'automatic'
@@ -118,7 +112,7 @@ class BaseStream:
     @classmethod
     def requirements_met(cls, catalog):
         selected_streams = [
-            s.stream for s in catalog.streams if is_selected(s)
+            s.stream for s in catalog.streams if is_stream_selected(s)
         ]
 
         return set(cls.REQUIRES).issubset(selected_streams)

--- a/tap_campaign_monitor/streams/base.py
+++ b/tap_campaign_monitor/streams/base.py
@@ -165,18 +165,6 @@ class BaseStream:
             'metadata': singer.metadata.to_list(mdata)
         }]
 
-    def transform_record(self, record):
-        with singer.Transformer() as tx:
-            metadata = {}
-
-            if self.catalog.metadata is not None:
-                metadata = singer.metadata.to_map(self.catalog.metadata)
-
-            return tx.transform(
-                record,
-                self.catalog.schema.to_dict(),
-                metadata)
-
     def get_catalog_keys(self):
         return list(self.catalog.schema.properties.keys())
 
@@ -185,40 +173,6 @@ class BaseStream:
             self.catalog.stream,
             self.catalog.schema.to_dict(),
             key_properties=self.catalog.key_properties)
-
-    def sync(self):
-        LOGGER.info('Syncing stream {} with {}'
-                    .format(self.catalog.tap_stream_id,
-                            self.__class__.__name__))
-
-        self.write_schema()
-
-        return self.sync_data()
-
-    def sync_data(self, substreams=None):
-        if substreams is None:
-            substreams = []
-
-        table = self.TABLE
-
-        url = self.get_url()
-
-        result = self.client.make_request(url, self.API_METHOD)
-
-        data = self.get_stream_data(result)
-
-        with singer.metrics.record_counter(endpoint=table) as counter:
-            for index, obj in enumerate(data):
-                LOGGER.debug("On {} of {}".format(index, len(data)))
-
-                singer.write_records(
-                    table,
-                    [self.transform_record(obj)])
-
-                counter.increment()
-
-                for substream in substreams:
-                    substream.sync_data(parent=obj)
 
     def transform_record(self, record):
         with CampaignMonitorTransformer(self.client.timezone) as tx:

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -181,20 +181,11 @@ class TestCampaignMonitorClient(unittest.TestCase):
             error_response = MagicMock()
             error_response.status_code = 429
 
-            mock_request.side_effect = [
-                error_response,
-                error_response,
-                error_response,
-                error_response,
-                error_response,
-                error_response,
-                error_response,
-                error_response
-            ]
+            mock_request.side_effect = [error_response] * 6
 
             with self.assertRaises(Server429Error):
                 client.make_request('https://dummy-url.com', 'GET')
-            self.assertEqual(mock_request.call_count, 7)
+            self.assertEqual(mock_request.call_count, 5)
 
     @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
     @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
@@ -210,14 +201,7 @@ class TestCampaignMonitorClient(unittest.TestCase):
             error_response = MagicMock()
             error_response.status_code = 500
 
-            mock_request.side_effect = [
-                error_response,
-                error_response,
-                error_response,
-                error_response,
-                error_response,
-                error_response
-            ]
+            mock_request.side_effect = [error_response] * 6
 
             with self.assertRaises(Server5xxError):
                 client.make_request('https://dummy-url.com', 'GET')

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -1,0 +1,222 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import requests
+from requests.exceptions import ConnectionError
+from tap_campaign_monitor.client import CampaignMonitorClient
+from tap_campaign_monitor.client import Server5xxError, Server429Error
+
+class TestCampaignMonitorClient(unittest.TestCase):
+
+    def setUp(self):
+        self.config = {
+            'refresh_token': 'dummy_refresh',
+            'client_id': 'dummy_client'
+        }
+
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
+    def test_successful_make_request(self, mock_get_timezone, mock_refresh_token):
+        """
+        Test that make_request successfully returns the JSON response
+        when the HTTP status code is 200.
+        Verifies that requests.request is called once with correct parameters.
+        """
+        mock_get_timezone.return_value = 'UTC'
+        mock_refresh_token.return_value = 'dummy_refresh_token'
+        client = CampaignMonitorClient(self.config)
+
+        with patch('requests.request') as mock_request:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {'data': 'ok'}
+            mock_request.return_value = mock_response
+
+            result = client.make_request('https://dummy-url.com', 'GET')
+
+            self.assertEqual(result, {'data': 'ok'})
+            mock_request.assert_called_once()
+
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
+    def test_make_request_server_5xx_error_retry(self, mock_get_timezone, mock_refresh_token):
+        """
+        Test that make_request raises Server5xxError and retries when
+        the response status code is a 5xx server error.
+        Verifies that the function retries the request multiple times.
+        """
+        mock_get_timezone.return_value = 'UTC'
+        mock_refresh_token.return_value = 'dummy_refresh_token'
+        client = CampaignMonitorClient(self.config)
+
+        with patch('requests.request') as mock_request:
+            mock_response = MagicMock()
+            mock_response.status_code = 500
+            mock_request.return_value = mock_response
+
+            with self.assertRaises(Server5xxError):
+                client.make_request('https://dummy-url.com', 'GET')
+
+            self.assertGreaterEqual(mock_request.call_count, 2)
+
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
+    def test_make_request_rate_limit_429_retry(self, mock_get_timezone, mock_refresh_token):
+        """
+        Test that make_request raises Server429Error and retries when
+        the response status code is 429 (rate limit exceeded).
+        Verifies that exponential backoff retry logic is triggered.
+        """
+        mock_get_timezone.return_value = 'UTC'
+        mock_refresh_token.return_value = 'dummy_refresh_token'
+        client = CampaignMonitorClient(self.config)
+
+        with patch('requests.request') as mock_request:
+            mock_response = MagicMock()
+            mock_response.status_code = 429
+            mock_request.return_value = mock_response
+
+            with self.assertRaises(Server429Error):
+                client.make_request('https://dummy-url.com', 'GET')
+
+            self.assertGreaterEqual(mock_request.call_count, 2)
+
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
+    def test_make_request_raises_runtime_error_for_other_errors(self, mock_get_timezone, mock_refresh_token):
+        """
+        Test that make_request raises RuntimeError for non-retryable HTTP errors,
+        such as 400 Bad Request, with the error message propagated.
+        Ensures no retries occur for these errors.
+        """
+        mock_get_timezone.return_value = 'UTC'
+        mock_refresh_token.return_value = 'dummy_refresh_token'
+        client = CampaignMonitorClient(self.config)
+
+        with patch('requests.request') as mock_request:
+            mock_response = MagicMock()
+            mock_response.status_code = 400
+            mock_response.text = "Bad Request"
+            mock_request.return_value = mock_response
+
+            with self.assertRaises(RuntimeError) as context:
+                client.make_request('https://dummy-url.com', 'POST')
+
+            self.assertIn("Bad Request", str(context.exception))
+            mock_request.assert_called_once()
+
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
+    def test_make_request_with_params_and_body(self, mock_get_timezone, mock_refresh_token):
+        """
+        Test that make_request correctly sends provided query parameters and JSON body
+        in the request, and returns the expected JSON response.
+        Verifies that the request includes correct headers and payload.
+        """
+        mock_get_timezone.return_value = 'UTC'
+        mock_refresh_token.return_value = 'dummy_refresh_token'
+        client = CampaignMonitorClient(self.config)
+
+        with patch('requests.request') as mock_request:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {'status': 'created'}
+            mock_request.return_value = mock_response
+
+            result = client.make_request(
+                'https://dummy-url.com',
+                'POST',
+                params={'a': 'b'},
+                body={'x': 'y'}
+            )
+
+            self.assertEqual(result, {'status': 'created'})
+            mock_request.assert_called_once_with(
+                'POST',
+                'https://dummy-url.com',
+                headers={
+                    'Content-Type': 'application/json',
+                    'Authorization': f'Bearer {client.access_token}'
+                },
+                params={'a': 'b'},
+                json={'x': 'y'}
+            )
+
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
+    def test_make_request_eventually_succeeds_after_retry(self, mock_get_timezone, mock_refresh_token):
+        """
+        Test that make_request retries on transient 5xx errors and eventually
+        succeeds returning the JSON response once a successful status code is received.
+        Confirms retry attempts occur before success.
+        """
+        mock_get_timezone.return_value = 'UTC'
+        mock_refresh_token.return_value = 'dummy_refresh_token'
+        client = CampaignMonitorClient(self.config)
+
+        with patch('requests.request') as mock_request:
+            error_response = MagicMock()
+            error_response.status_code = 502
+
+            success_response = MagicMock()
+            success_response.status_code = 200
+            success_response.json.return_value = {'success': True}
+
+            mock_request.side_effect = [error_response, error_response, success_response]
+
+            result = client.make_request('https://dummy-url.com', 'GET')
+            self.assertEqual(result, {'success': True})
+            self.assertEqual(mock_request.call_count, 3)
+
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
+    def test_make_request_max_retries_reached_for_Server429Error(self, mock_get_timezone, mock_refresh_token):
+        """
+        Test that make_request raises Server429Error after exceeding maximum retry attempts.
+        """
+        mock_get_timezone.return_value = 'UTC'
+        mock_refresh_token.return_value = 'dummy_refresh_token'
+        client = CampaignMonitorClient(self.config)
+
+        with patch('requests.request') as mock_request:
+            error_response = MagicMock()
+            error_response.status_code = 429
+
+            mock_request.side_effect = [
+                error_response,
+                error_response,
+                error_response,
+                error_response,
+                error_response,
+                error_response
+            ]
+
+            with self.assertRaises(Server429Error):
+                client.make_request('https://dummy-url.com', 'GET')
+            self.assertEqual(mock_request.call_count, 5)
+
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
+    def test_make_request_max_retries_reached_for_Server5xxError(self, mock_get_timezone, mock_refresh_token):
+        """
+        Test that make_request raises Server5xxError after exceeding maximum retry attempts.
+        """
+        mock_get_timezone.return_value = 'UTC'
+        mock_refresh_token.return_value = 'dummy_refresh_token'
+        client = CampaignMonitorClient(self.config)
+
+        with patch('requests.request') as mock_request:
+            error_response = MagicMock()
+            error_response.status_code = 500
+
+            mock_request.side_effect = [
+                error_response,
+                error_response,
+                error_response,
+                error_response,
+                error_response,
+                error_response
+            ]
+
+            with self.assertRaises(Server5xxError):
+                client.make_request('https://dummy-url.com', 'GET')
+            self.assertEqual(mock_request.call_count, 5)

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -8,7 +8,24 @@ from tap_campaign_monitor.client import (
 )
 
 
-class TestCampaignMonitorClient(unittest.TestCase):
+from unittest.mock import patch
+
+
+class BaseTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._patcher = patch("tap_campaign_monitor.client.RETRY_RATE_LIMIT")
+        cls.mocked_retry_rate_limit = cls._patcher.start()
+        cls.mocked_retry_rate_limit.return_value = 1
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._patcher.stop()
+        super().tearDownClass()
+
+
+class TestCampaignMonitorClient(BaseTestCase):
 
     def setUp(self):
         self.config = {"refresh_token": "dummy_refresh", "client_id": "dummy_client"}

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -169,6 +169,26 @@ class TestCampaignMonitorClient(unittest.TestCase):
 
     @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
     @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
+    def test_make_request_max_retries_reached_for_Server5xxError(self, mock_get_timezone, mock_refresh_token):
+        """
+        Test that make_request raises Server5xxError after exceeding maximum retry attempts.
+        """
+        mock_get_timezone.return_value = 'UTC'
+        mock_refresh_token.return_value = 'dummy_refresh_token'
+        client = CampaignMonitorClient(self.config)
+
+        with patch('requests.request') as mock_request:
+            error_response = MagicMock()
+            error_response.status_code = 500
+
+            mock_request.side_effect = [error_response] * 6
+
+            with self.assertRaises(Server5xxError):
+                client.make_request('https://dummy-url.com', 'GET')
+            self.assertEqual(mock_request.call_count, 5)
+
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
     def test_make_request_max_retries_reached_for_Server429Error(self, mock_get_timezone, mock_refresh_token):
         """
         Test that make_request raises Server429Error after exceeding maximum retry attempts.
@@ -189,9 +209,12 @@ class TestCampaignMonitorClient(unittest.TestCase):
 
     @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
     @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
-    def test_make_request_max_retries_reached_for_Server5xxError(self, mock_get_timezone, mock_refresh_token):
+    @patch('tap_campaign_monitor.client.sleep')
+    @patch('tap_campaign_monitor.client.LOGGER')
+    def test_make_request_429_with_valid_retry_after(self, mock_logger, mock_sleep, mock_get_timezone, mock_refresh_token):
         """
-        Test that make_request raises Server5xxError after exceeding maximum retry attempts.
+        Test that make_request respects the retry_after value from X-RateLimit-Reset header
+        when handling Server429Error, with correct logging and sleep behavior.
         """
         mock_get_timezone.return_value = 'UTC'
         mock_refresh_token.return_value = 'dummy_refresh_token'
@@ -199,10 +222,71 @@ class TestCampaignMonitorClient(unittest.TestCase):
 
         with patch('requests.request') as mock_request:
             error_response = MagicMock()
-            error_response.status_code = 500
+            error_response.status_code = 429
+            error_response.headers = {'X-RateLimit-Reset': '10'}
 
-            mock_request.side_effect = [error_response] * 6
+            mock_request.side_effect = [error_response] * 2 + [MagicMock(status_code=200, json=lambda: {'data': 'ok'})]
 
-            with self.assertRaises(Server5xxError):
-                client.make_request('https://dummy-url.com', 'GET')
-            self.assertEqual(mock_request.call_count, 5)
+            result = client.make_request('https://dummy-url.com', 'GET')
+            self.assertEqual(result, {'data': 'ok'})
+            self.assertEqual(mock_request.call_count, 3)
+            mock_sleep.assert_called_with(10)
+            mock_logger.warning.assert_called_with(
+                f"[RateLimit] Retrying make_request, attempt 2, waiting 10s due to rate limit {repr(Server429Error(retry_after=10))}"
+            )
+
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
+    @patch('tap_campaign_monitor.client.sleep')
+    @patch('tap_campaign_monitor.client.LOGGER')
+    def test_make_request_429_missing_retry_after(self, mock_logger, mock_sleep, mock_get_timezone, mock_refresh_token):
+        """
+        Test that make_request uses default retry_after (360s) when X-RateLimit-Reset header
+        is missing for Server429Error, with correct logging and sleep behavior.
+        """
+        mock_get_timezone.return_value = 'UTC'
+        mock_refresh_token.return_value = 'dummy_refresh_token'
+        client = CampaignMonitorClient(self.config)
+
+        with patch('requests.request') as mock_request:
+            error_response = MagicMock()
+            error_response.status_code = 429
+            error_response.headers = {}
+
+            mock_request.side_effect = [error_response] * 2 + [MagicMock(status_code=200, json=lambda: {'data': 'ok'})]
+
+            result = client.make_request('https://dummy-url.com', 'GET')
+            self.assertEqual(result, {'data': 'ok'})
+            self.assertEqual(mock_request.call_count, 3)
+            mock_sleep.assert_called_with(360)
+            mock_logger.warning.assert_called_with(
+                f"[RateLimit] Retrying make_request, attempt 2, waiting 360s due to rate limit {repr(Server429Error(retry_after=360))}"
+            )
+
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
+    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
+    @patch('tap_campaign_monitor.client.sleep')
+    @patch('tap_campaign_monitor.client.LOGGER')
+    def test_make_request_429_invalid_retry_after(self, mock_logger, mock_sleep, mock_get_timezone, mock_refresh_token):
+        """
+        Test that make_request sets retry_after to None when X-RateLimit-Reset header
+        contains an invalid value for Server429Error, defaulting to 0s sleep.
+        """
+        mock_get_timezone.return_value = 'UTC'
+        mock_refresh_token.return_value = 'dummy_refresh_token'
+        client = CampaignMonitorClient(self.config)
+
+        with patch('requests.request') as mock_request:
+            error_response = MagicMock()
+            error_response.status_code = 429
+            error_response.headers = {'X-RateLimit-Reset': 'invalid'}
+
+            mock_request.side_effect = [error_response] * 2 + [MagicMock(status_code=200, json=lambda: {'data': 'ok'})]
+
+            result = client.make_request('https://dummy-url.com', 'GET')
+            self.assertEqual(result, {'data': 'ok'})
+            self.assertEqual(mock_request.call_count, 3)
+            mock_sleep.assert_called_with(0)
+            mock_logger.warning.assert_called_with(
+                f"[RateLimit] Retrying make_request, attempt 2, waiting 0s due to rate limit {repr(Server429Error(retry_after=None))}"
+            )

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -222,7 +222,6 @@ class TestCampaignMonitorClient(unittest.TestCase):
                 client.make_request("https://dummy-url.com", "GET")
             self.assertEqual(mock_request.call_count, 5)
 
-    @patch("tap_campaign_monitor.client.LOGGER.warning")
     @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
     @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
     @patch("tap_campaign_monitor.client.CampaignMonitorClient._rate_limit_backoff")
@@ -335,8 +334,7 @@ class TestCampaignMonitorClient(unittest.TestCase):
     ):
         """
         Test that make_request actually drives the _rate_limit_backoff generator
-        for 429 errors: we patch time.sleep to capture the wait value, and
-        patch LOGGER.warning to ensure it logs the same wait.
+        for 429 errors: we patch time.sleep to capture the wait value
         """
         mock_get_timezone.return_value = "UTC"
         mock_refresh_token.return_value = "dummy_refresh_token"

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -187,12 +187,14 @@ class TestCampaignMonitorClient(unittest.TestCase):
                 error_response,
                 error_response,
                 error_response,
+                error_response,
+                error_response,
                 error_response
             ]
 
             with self.assertRaises(Server429Error):
                 client.make_request('https://dummy-url.com', 'GET')
-            self.assertEqual(mock_request.call_count, 5)
+            self.assertEqual(mock_request.call_count, 7)
 
     @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
     @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -1,292 +1,320 @@
 import unittest
 from unittest.mock import patch, MagicMock
 import requests
-from requests.exceptions import ConnectionError
-from tap_campaign_monitor.client import CampaignMonitorClient
-from tap_campaign_monitor.client import Server5xxError, Server429Error
+from tap_campaign_monitor.client import (
+    CampaignMonitorClient,
+    Server429Error,
+    Server5xxError,
+    RETRY_RATE_LIMIT,
+)
+
 
 class TestCampaignMonitorClient(unittest.TestCase):
 
     def setUp(self):
-        self.config = {
-            'refresh_token': 'dummy_refresh',
-            'client_id': 'dummy_client'
-        }
+        self.config = {"refresh_token": "dummy_refresh", "client_id": "dummy_client"}
 
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
     def test_successful_make_request(self, mock_get_timezone, mock_refresh_token):
         """
         Test that make_request successfully returns the JSON response
         when the HTTP status code is 200.
         Verifies that requests.request is called once with correct parameters.
         """
-        mock_get_timezone.return_value = 'UTC'
-        mock_refresh_token.return_value = 'dummy_refresh_token'
+        mock_get_timezone.return_value = "UTC"
+        mock_refresh_token.return_value = "dummy_refresh_token"
         client = CampaignMonitorClient(self.config)
 
-        with patch('requests.request') as mock_request:
+        with patch("requests.request") as mock_request:
             mock_response = MagicMock()
             mock_response.status_code = 200
-            mock_response.json.return_value = {'data': 'ok'}
+            mock_response.json.return_value = {"data": "ok"}
             mock_request.return_value = mock_response
 
-            result = client.make_request('https://dummy-url.com', 'GET')
+            result = client.make_request("https://dummy-url.com", "GET")
 
-            self.assertEqual(result, {'data': 'ok'})
+            self.assertEqual(result, {"data": "ok"})
             mock_request.assert_called_once()
 
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
-    def test_make_request_server_5xx_error_retry(self, mock_get_timezone, mock_refresh_token):
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
+    def test_make_request_server_5xx_error_retry(
+        self, mock_get_timezone, mock_refresh_token
+    ):
         """
         Test that make_request raises Server5xxError and retries when
         the response status code is a 5xx server error.
         Verifies that the function retries the request multiple times.
         """
-        mock_get_timezone.return_value = 'UTC'
-        mock_refresh_token.return_value = 'dummy_refresh_token'
+        mock_get_timezone.return_value = "UTC"
+        mock_refresh_token.return_value = "dummy_refresh_token"
         client = CampaignMonitorClient(self.config)
 
-        with patch('requests.request') as mock_request:
+        with patch("requests.request") as mock_request:
             mock_response = MagicMock()
             mock_response.status_code = 500
             mock_request.return_value = mock_response
 
             with self.assertRaises(Server5xxError):
-                client.make_request('https://dummy-url.com', 'GET')
+                client.make_request("https://dummy-url.com", "GET")
 
             self.assertGreaterEqual(mock_request.call_count, 2)
 
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
-    def test_make_request_rate_limit_429_retry(self, mock_get_timezone, mock_refresh_token):
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
+    def test_make_request_rate_limit_429_retry(
+        self, mock_get_timezone, mock_refresh_token
+    ):
         """
         Test that make_request raises Server429Error and retries when
         the response status code is 429 (rate limit exceeded).
         Verifies that exponential backoff retry logic is triggered.
         """
-        mock_get_timezone.return_value = 'UTC'
-        mock_refresh_token.return_value = 'dummy_refresh_token'
+        mock_get_timezone.return_value = "UTC"
+        mock_refresh_token.return_value = "dummy_refresh_token"
         client = CampaignMonitorClient(self.config)
 
-        with patch('requests.request') as mock_request:
+        with patch("requests.request") as mock_request:
             mock_response = MagicMock()
             mock_response.status_code = 429
             mock_request.return_value = mock_response
 
             with self.assertRaises(Server429Error):
-                client.make_request('https://dummy-url.com', 'GET')
+                client.make_request("https://dummy-url.com", "GET")
 
             self.assertGreaterEqual(mock_request.call_count, 2)
 
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
-    def test_make_request_raises_runtime_error_for_other_errors(self, mock_get_timezone, mock_refresh_token):
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
+    def test_make_request_raises_runtime_error_for_other_errors(
+        self, mock_get_timezone, mock_refresh_token
+    ):
         """
         Test that make_request raises RuntimeError for non-retryable HTTP errors,
         such as 400 Bad Request, with the error message propagated.
         Ensures no retries occur for these errors.
         """
-        mock_get_timezone.return_value = 'UTC'
-        mock_refresh_token.return_value = 'dummy_refresh_token'
+        mock_get_timezone.return_value = "UTC"
+        mock_refresh_token.return_value = "dummy_refresh_token"
         client = CampaignMonitorClient(self.config)
 
-        with patch('requests.request') as mock_request:
+        with patch("requests.request") as mock_request:
             mock_response = MagicMock()
             mock_response.status_code = 400
             mock_response.text = "Bad Request"
             mock_request.return_value = mock_response
 
             with self.assertRaises(RuntimeError) as context:
-                client.make_request('https://dummy-url.com', 'POST')
+                client.make_request("https://dummy-url.com", "POST")
 
             self.assertIn("Bad Request", str(context.exception))
             mock_request.assert_called_once()
 
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
-    def test_make_request_with_params_and_body(self, mock_get_timezone, mock_refresh_token):
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
+    def test_make_request_with_params_and_body(
+        self, mock_get_timezone, mock_refresh_token
+    ):
         """
         Test that make_request correctly sends provided query parameters and JSON body
         in the request, and returns the expected JSON response.
         Verifies that the request includes correct headers and payload.
         """
-        mock_get_timezone.return_value = 'UTC'
-        mock_refresh_token.return_value = 'dummy_refresh_token'
+        mock_get_timezone.return_value = "UTC"
+        mock_refresh_token.return_value = "dummy_refresh_token"
         client = CampaignMonitorClient(self.config)
 
-        with patch('requests.request') as mock_request:
+        with patch("requests.request") as mock_request:
             mock_response = MagicMock()
             mock_response.status_code = 200
-            mock_response.json.return_value = {'status': 'created'}
+            mock_response.json.return_value = {"status": "created"}
             mock_request.return_value = mock_response
 
             result = client.make_request(
-                'https://dummy-url.com',
-                'POST',
-                params={'a': 'b'},
-                body={'x': 'y'}
+                "https://dummy-url.com", "POST", params={"a": "b"}, body={"x": "y"}
             )
 
-            self.assertEqual(result, {'status': 'created'})
+            self.assertEqual(result, {"status": "created"})
             mock_request.assert_called_once_with(
-                'POST',
-                'https://dummy-url.com',
+                "POST",
+                "https://dummy-url.com",
                 headers={
-                    'Content-Type': 'application/json',
-                    'Authorization': f'Bearer {client.access_token}'
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {client.access_token}",
                 },
-                params={'a': 'b'},
-                json={'x': 'y'}
+                params={"a": "b"},
+                json={"x": "y"},
             )
 
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
-    def test_make_request_eventually_succeeds_after_retry(self, mock_get_timezone, mock_refresh_token):
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
+    def test_make_request_eventually_succeeds_after_retry(
+        self, mock_get_timezone, mock_refresh_token
+    ):
         """
         Test that make_request retries on transient 5xx errors and eventually
         succeeds returning the JSON response once a successful status code is received.
         Confirms retry attempts occur before success.
         """
-        mock_get_timezone.return_value = 'UTC'
-        mock_refresh_token.return_value = 'dummy_refresh_token'
+        mock_get_timezone.return_value = "UTC"
+        mock_refresh_token.return_value = "dummy_refresh_token"
         client = CampaignMonitorClient(self.config)
 
-        with patch('requests.request') as mock_request:
+        with patch("requests.request") as mock_request:
             error_response = MagicMock()
             error_response.status_code = 502
 
             success_response = MagicMock()
             success_response.status_code = 200
-            success_response.json.return_value = {'success': True}
+            success_response.json.return_value = {"success": True}
 
-            mock_request.side_effect = [error_response, error_response, success_response]
+            mock_request.side_effect = [
+                error_response,
+                error_response,
+                success_response,
+            ]
 
-            result = client.make_request('https://dummy-url.com', 'GET')
-            self.assertEqual(result, {'success': True})
+            result = client.make_request("https://dummy-url.com", "GET")
+            self.assertEqual(result, {"success": True})
             self.assertEqual(mock_request.call_count, 3)
 
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
-    def test_make_request_max_retries_reached_for_Server5xxError(self, mock_get_timezone, mock_refresh_token):
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
+    def test_make_request_max_retries_reached_for_Server5xxError(
+        self, mock_get_timezone, mock_refresh_token
+    ):
         """
         Test that make_request raises Server5xxError after exceeding maximum retry attempts.
         """
-        mock_get_timezone.return_value = 'UTC'
-        mock_refresh_token.return_value = 'dummy_refresh_token'
+        mock_get_timezone.return_value = "UTC"
+        mock_refresh_token.return_value = "dummy_refresh_token"
         client = CampaignMonitorClient(self.config)
 
-        with patch('requests.request') as mock_request:
+        with patch("requests.request") as mock_request:
             error_response = MagicMock()
             error_response.status_code = 500
 
             mock_request.side_effect = [error_response] * 6
 
             with self.assertRaises(Server5xxError):
-                client.make_request('https://dummy-url.com', 'GET')
+                client.make_request("https://dummy-url.com", "GET")
             self.assertEqual(mock_request.call_count, 5)
 
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
-    def test_make_request_max_retries_reached_for_Server429Error(self, mock_get_timezone, mock_refresh_token):
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
+    def test_make_request_max_retries_reached_for_Server429Error(
+        self, mock_get_timezone, mock_refresh_token
+    ):
         """
         Test that make_request raises Server429Error after exceeding maximum retry attempts.
         """
-        mock_get_timezone.return_value = 'UTC'
-        mock_refresh_token.return_value = 'dummy_refresh_token'
+        mock_get_timezone.return_value = "UTC"
+        mock_refresh_token.return_value = "dummy_refresh_token"
         client = CampaignMonitorClient(self.config)
 
-        with patch('requests.request') as mock_request:
+        with patch("requests.request") as mock_request:
             error_response = MagicMock()
             error_response.status_code = 429
 
             mock_request.side_effect = [error_response] * 6
 
             with self.assertRaises(Server429Error):
-                client.make_request('https://dummy-url.com', 'GET')
+                client.make_request("https://dummy-url.com", "GET")
             self.assertEqual(mock_request.call_count, 5)
 
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
-    @patch('tap_campaign_monitor.client.sleep')
-    @patch('tap_campaign_monitor.client.LOGGER')
-    def test_make_request_429_with_valid_retry_after(self, mock_logger, mock_sleep, mock_get_timezone, mock_refresh_token):
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
+    @patch("tap_campaign_monitor.client.sleep")
+    @patch("tap_campaign_monitor.client.LOGGER")
+    def test_make_request_429_with_valid_retry_after(
+        self, mock_logger, mock_sleep, mock_get_timezone, mock_refresh_token
+    ):
         """
         Test that make_request respects the retry_after value from X-RateLimit-Reset header
         when handling Server429Error, with correct logging and sleep behavior.
         """
-        mock_get_timezone.return_value = 'UTC'
-        mock_refresh_token.return_value = 'dummy_refresh_token'
+        mock_get_timezone.return_value = "UTC"
+        mock_refresh_token.return_value = "dummy_refresh_token"
         client = CampaignMonitorClient(self.config)
 
-        with patch('requests.request') as mock_request:
+        with patch("requests.request") as mock_request:
             error_response = MagicMock()
             error_response.status_code = 429
-            error_response.headers = {'X-RateLimit-Reset': '10'}
+            error_response.headers = {"X-RateLimit-Reset": "10"}
 
-            mock_request.side_effect = [error_response] * 2 + [MagicMock(status_code=200, json=lambda: {'data': 'ok'})]
+            mock_request.side_effect = [error_response] * 2 + [
+                MagicMock(status_code=200, json=lambda: {"data": "ok"})
+            ]
 
-            result = client.make_request('https://dummy-url.com', 'GET')
-            self.assertEqual(result, {'data': 'ok'})
+            result = client.make_request("https://dummy-url.com", "GET")
+            self.assertEqual(result, {"data": "ok"})
             self.assertEqual(mock_request.call_count, 3)
             mock_sleep.assert_called_with(10)
             mock_logger.warning.assert_called_with(
                 f"[RateLimit] Retrying make_request, attempt 2, waiting 10s due to rate limit {repr(Server429Error(retry_after=10))}"
             )
 
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
-    @patch('tap_campaign_monitor.client.sleep')
-    @patch('tap_campaign_monitor.client.LOGGER')
-    def test_make_request_429_missing_retry_after(self, mock_logger, mock_sleep, mock_get_timezone, mock_refresh_token):
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
+    @patch("tap_campaign_monitor.client.sleep")
+    @patch("tap_campaign_monitor.client.LOGGER")
+    def test_make_request_429_missing_retry_after(
+        self, mock_logger, mock_sleep, mock_get_timezone, mock_refresh_token
+    ):
         """
-        Test that make_request uses default retry_after (360s) when X-RateLimit-Reset header
+        Test that make_request uses default retry_after when X-RateLimit-Reset header
         is missing for Server429Error, with correct logging and sleep behavior.
         """
-        mock_get_timezone.return_value = 'UTC'
-        mock_refresh_token.return_value = 'dummy_refresh_token'
+        mock_get_timezone.return_value = "UTC"
+        mock_refresh_token.return_value = "dummy_refresh_token"
         client = CampaignMonitorClient(self.config)
 
-        with patch('requests.request') as mock_request:
+        with patch("requests.request") as mock_request:
             error_response = MagicMock()
             error_response.status_code = 429
             error_response.headers = {}
 
-            mock_request.side_effect = [error_response] * 2 + [MagicMock(status_code=200, json=lambda: {'data': 'ok'})]
+            mock_request.side_effect = [error_response] * 2 + [
+                MagicMock(status_code=200, json=lambda: {"data": "ok"})
+            ]
 
-            result = client.make_request('https://dummy-url.com', 'GET')
-            self.assertEqual(result, {'data': 'ok'})
+            result = client.make_request("https://dummy-url.com", "GET")
+            self.assertEqual(result, {"data": "ok"})
             self.assertEqual(mock_request.call_count, 3)
-            mock_sleep.assert_called_with(360)
+            mock_sleep.assert_called_with(RETRY_RATE_LIMIT)
             mock_logger.warning.assert_called_with(
-                f"[RateLimit] Retrying make_request, attempt 2, waiting 360s due to rate limit {repr(Server429Error(retry_after=360))}"
+                f"[RateLimit] Retrying make_request, attempt 2, waiting {RETRY_RATE_LIMIT}s due to rate limit {repr(Server429Error(retry_after=RETRY_RATE_LIMIT))}"
             )
 
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token')
-    @patch('tap_campaign_monitor.client.CampaignMonitorClient.get_timezone')
-    @patch('tap_campaign_monitor.client.sleep')
-    @patch('tap_campaign_monitor.client.LOGGER')
-    def test_make_request_429_invalid_retry_after(self, mock_logger, mock_sleep, mock_get_timezone, mock_refresh_token):
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
+    @patch("tap_campaign_monitor.client.sleep")
+    @patch("tap_campaign_monitor.client.LOGGER")
+    def test_make_request_429_invalid_retry_after(
+        self, mock_logger, mock_sleep, mock_get_timezone, mock_refresh_token
+    ):
         """
         Test that make_request sets retry_after to None when X-RateLimit-Reset header
         contains an invalid value for Server429Error, defaulting to 0s sleep.
         """
-        mock_get_timezone.return_value = 'UTC'
-        mock_refresh_token.return_value = 'dummy_refresh_token'
+        mock_get_timezone.return_value = "UTC"
+        mock_refresh_token.return_value = "dummy_refresh_token"
         client = CampaignMonitorClient(self.config)
 
-        with patch('requests.request') as mock_request:
+        with patch("requests.request") as mock_request:
             error_response = MagicMock()
             error_response.status_code = 429
-            error_response.headers = {'X-RateLimit-Reset': 'invalid'}
+            error_response.headers = {"X-RateLimit-Reset": "invalid"}
 
-            mock_request.side_effect = [error_response] * 2 + [MagicMock(status_code=200, json=lambda: {'data': 'ok'})]
+            mock_request.side_effect = [error_response] * 2 + [
+                MagicMock(status_code=200, json=lambda: {"data": "ok"})
+            ]
 
-            result = client.make_request('https://dummy-url.com', 'GET')
-            self.assertEqual(result, {'data': 'ok'})
+            result = client.make_request("https://dummy-url.com", "GET")
+            self.assertEqual(result, {"data": "ok"})
             self.assertEqual(mock_request.call_count, 3)
-            mock_sleep.assert_called_with(360)
+            mock_sleep.assert_called_with(RETRY_RATE_LIMIT)
             mock_logger.warning.assert_called_with(
-                f"[RateLimit] Retrying make_request, attempt 2, waiting 360s due to rate limit {repr(Server429Error(retry_after=None))}"
+                f"[RateLimit] Retrying make_request, attempt 2, waiting {RETRY_RATE_LIMIT}s due to rate limit {repr(Server429Error(retry_after=None))}"
             )

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -222,10 +222,16 @@ class TestCampaignMonitorClient(unittest.TestCase):
                 client.make_request("https://dummy-url.com", "GET")
             self.assertEqual(mock_request.call_count, 5)
 
+    @patch("tap_campaign_monitor.client.LOGGER.warning")
     @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
     @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient._rate_limit_backoff")
     def test_make_request_429_with_valid_retry_after(
-        self, mock_get_timezone, mock_refresh_token
+        self,
+        mock_warning,
+        mock_rate_limit_backoff,
+        mock_get_timezone,
+        mock_refresh_token,
     ):
         """
         Test that make_request respects the retry_after value from X-RateLimit-Reset header
@@ -240,13 +246,14 @@ class TestCampaignMonitorClient(unittest.TestCase):
             error_response.status_code = 429
             error_response.headers = {"X-RateLimit-Reset": "10"}
 
-            mock_request.side_effect = [error_response] * 2 + [
+            mock_request.side_effect = [error_response] + [
                 MagicMock(status_code=200, json=lambda: {"data": "ok"})
             ]
 
             result = client.make_request("https://dummy-url.com", "GET")
             self.assertEqual(result, {"data": "ok"})
-            self.assertEqual(mock_request.call_count, 3)
+            self.assertEqual(mock_request.call_count, 2)
+            mock_rate_limit_backoff.assert_called_once()
 
     @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
     @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
@@ -305,7 +312,7 @@ class TestCampaignMonitorClient(unittest.TestCase):
     def test_rate_limit_backoff_generator(self, mock_get_timezone, mock_refresh_token):
         """
         Test that the custom backoff generator `_rate_limit_backoff` yields the most recent
-        `retry_after` value set on the CampaignMonitorClient instance. Ensures that the 
+        `retry_after` value set on the CampaignMonitorClient instance. Ensures that the
         generator dynamically reflects updates to the `_retry_after` attribute.
         """
         mock_get_timezone.return_value = "UTC"
@@ -320,3 +327,38 @@ class TestCampaignMonitorClient(unittest.TestCase):
         # change retry_after and test again
         client._retry_after = 10
         self.assertEqual(next(gen), 10)
+
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
+    def test_make_request_uses_rate_limit_backoff_generator(
+        self, mock_get_timezone, mock_refresh_token
+    ):
+        """
+        Test that make_request actually drives the _rate_limit_backoff generator
+        for 429 errors: we patch time.sleep to capture the wait value, and
+        patch LOGGER.warning to ensure it logs the same wait.
+        """
+        mock_get_timezone.return_value = "UTC"
+        mock_refresh_token.return_value = "dummy_refresh_token"
+        client = CampaignMonitorClient(self.config)
+
+        error_response = MagicMock(status_code=429)
+        error_response.headers = {"X-RateLimit-Reset": "7"}
+
+        success_response = MagicMock(status_code=200)
+        success_response.json.return_value = {"data": "ok"}
+
+        with patch(
+            "requests.request", side_effect=[error_response, success_response]
+        ) as mock_request, patch("time.sleep") as mock_sleep:
+
+            result = client.make_request("https://dummy-url.com", "GET")
+
+            self.assertEqual(result, {"data": "ok"})
+            self.assertEqual(mock_request.call_count, 2)
+
+            # Since the HTTP 429 retry logic derives its sleep interval directly
+            # from the _rate_limit_backoff generator, asserting that time.sleep(7)
+            # is called both confirms that the backoff mechanism was invoked and
+            # that _rate_limit_backoff yielded the expected value of 7 second
+            mock_sleep.assert_called_once_with(7)

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -227,7 +227,6 @@ class TestCampaignMonitorClient(unittest.TestCase):
     @patch("tap_campaign_monitor.client.CampaignMonitorClient._rate_limit_backoff")
     def test_make_request_429_with_valid_retry_after(
         self,
-        mock_warning,
         mock_rate_limit_backoff,
         mock_get_timezone,
         mock_refresh_token,

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -5,7 +5,6 @@ from tap_campaign_monitor.client import (
     CampaignMonitorClient,
     Server429Error,
     Server5xxError,
-    RETRY_RATE_LIMIT,
 )
 
 
@@ -225,14 +224,12 @@ class TestCampaignMonitorClient(unittest.TestCase):
 
     @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
     @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
-    @patch("tap_campaign_monitor.client.sleep")
-    @patch("tap_campaign_monitor.client.LOGGER")
     def test_make_request_429_with_valid_retry_after(
-        self, mock_logger, mock_sleep, mock_get_timezone, mock_refresh_token
+        self, mock_get_timezone, mock_refresh_token
     ):
         """
         Test that make_request respects the retry_after value from X-RateLimit-Reset header
-        when handling Server429Error, with correct logging and sleep behavior.
+        when handling Server429Error.
         """
         mock_get_timezone.return_value = "UTC"
         mock_refresh_token.return_value = "dummy_refresh_token"
@@ -250,21 +247,15 @@ class TestCampaignMonitorClient(unittest.TestCase):
             result = client.make_request("https://dummy-url.com", "GET")
             self.assertEqual(result, {"data": "ok"})
             self.assertEqual(mock_request.call_count, 3)
-            mock_sleep.assert_called_with(10)
-            mock_logger.warning.assert_called_with(
-                f"[RateLimit] Retrying make_request, attempt 2, waiting 10s due to rate limit {repr(Server429Error(retry_after=10))}"
-            )
 
     @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
     @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
-    @patch("tap_campaign_monitor.client.sleep")
-    @patch("tap_campaign_monitor.client.LOGGER")
     def test_make_request_429_missing_retry_after(
-        self, mock_logger, mock_sleep, mock_get_timezone, mock_refresh_token
+        self, mock_get_timezone, mock_refresh_token
     ):
         """
         Test that make_request uses default retry_after when X-RateLimit-Reset header
-        is missing for Server429Error, with correct logging and sleep behavior.
+        is missing for Server429Error
         """
         mock_get_timezone.return_value = "UTC"
         mock_refresh_token.return_value = "dummy_refresh_token"
@@ -282,21 +273,15 @@ class TestCampaignMonitorClient(unittest.TestCase):
             result = client.make_request("https://dummy-url.com", "GET")
             self.assertEqual(result, {"data": "ok"})
             self.assertEqual(mock_request.call_count, 3)
-            mock_sleep.assert_called_with(RETRY_RATE_LIMIT)
-            mock_logger.warning.assert_called_with(
-                f"[RateLimit] Retrying make_request, attempt 2, waiting {RETRY_RATE_LIMIT}s due to rate limit {repr(Server429Error(retry_after=RETRY_RATE_LIMIT))}"
-            )
 
     @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
     @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
-    @patch("tap_campaign_monitor.client.sleep")
-    @patch("tap_campaign_monitor.client.LOGGER")
     def test_make_request_429_invalid_retry_after(
-        self, mock_logger, mock_sleep, mock_get_timezone, mock_refresh_token
+        self, mock_get_timezone, mock_refresh_token
     ):
         """
         Test that make_request sets retry_after to None when X-RateLimit-Reset header
-        contains an invalid value for Server429Error, defaulting to 0s sleep.
+        contains an invalid value for Server429Error.
         """
         mock_get_timezone.return_value = "UTC"
         mock_refresh_token.return_value = "dummy_refresh_token"
@@ -314,7 +299,19 @@ class TestCampaignMonitorClient(unittest.TestCase):
             result = client.make_request("https://dummy-url.com", "GET")
             self.assertEqual(result, {"data": "ok"})
             self.assertEqual(mock_request.call_count, 3)
-            mock_sleep.assert_called_with(RETRY_RATE_LIMIT)
-            mock_logger.warning.assert_called_with(
-                f"[RateLimit] Retrying make_request, attempt 2, waiting {RETRY_RATE_LIMIT}s due to rate limit {repr(Server429Error(retry_after=None))}"
-            )
+
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
+    @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
+    def test_rate_limit_backoff_generator(self, mock_get_timezone, mock_refresh_token):
+        mock_get_timezone.return_value = "UTC"
+        mock_refresh_token.return_value = "dummy_refresh_token"
+        client = CampaignMonitorClient(self.config)
+
+        # manually set retry_after and test generator
+        client._retry_after = 7
+        gen = client._rate_limit_backoff()
+        self.assertEqual(next(gen), 7)
+
+        # change retry_after and test again
+        client._retry_after = 10
+        self.assertEqual(next(gen), 10)

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -286,7 +286,7 @@ class TestCampaignMonitorClient(unittest.TestCase):
             result = client.make_request('https://dummy-url.com', 'GET')
             self.assertEqual(result, {'data': 'ok'})
             self.assertEqual(mock_request.call_count, 3)
-            mock_sleep.assert_called_with(0)
+            mock_sleep.assert_called_with(360)
             mock_logger.warning.assert_called_with(
-                f"[RateLimit] Retrying make_request, attempt 2, waiting 0s due to rate limit {repr(Server429Error(retry_after=None))}"
+                f"[RateLimit] Retrying make_request, attempt 2, waiting 360s due to rate limit {repr(Server429Error(retry_after=None))}"
             )

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -303,6 +303,11 @@ class TestCampaignMonitorClient(unittest.TestCase):
     @patch("tap_campaign_monitor.client.CampaignMonitorClient.refresh_access_token")
     @patch("tap_campaign_monitor.client.CampaignMonitorClient.get_timezone")
     def test_rate_limit_backoff_generator(self, mock_get_timezone, mock_refresh_token):
+        """
+        Test that the custom backoff generator `_rate_limit_backoff` yields the most recent
+        `retry_after` value set on the CampaignMonitorClient instance. Ensures that the 
+        generator dynamically reflects updates to the `_retry_after` attribute.
+        """
         mock_get_timezone.return_value = "UTC"
         mock_refresh_token.return_value = "dummy_refresh_token"
         client = CampaignMonitorClient(self.config)


### PR DESCRIPTION
# Description of change
- https://github.com/singer-io/tap-campaign-monitor/pull/8
**Replacement of the libraries**
- Removal
- [x] tap-framework==0.0.5
- Addition
- [x] singer-python==6.1.1
- [x] backoff==2.2.1
- [x] requests==2.32.3

# Manual QA steps

- [x] Discovery: running
- [x] Sync: running
- [x] Unit Tests: running
- [ ] Integration test: not implemented

# Notes
- pylint tests are not added in `.circleci/config.yml` as whole project does not follow linting standards and it leads to throwing of multiple errors.
 
# Rollback steps
 - revert this branch