### PR TITLE
[SAC-30995] - Unauthorized streams exclusion from catalog during discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ singer-check-tap-data
 *.pyc
 *.egg-info
 dist/
+tmp/
+venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.3.0
-- Streams the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error. [#17](https://github.com/singer-io/tap-campaign-monitor/pull/17)
+- Streams the credentials cannot access (HTTP 401/403) are excluded from the catalog during discovery (discovery still fails if no parent streams are accessible). [#17](https://github.com/singer-io/tap-campaign-monitor/pull/17)
 - Bump to requests==2.34.2
 
 ## 1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+- Streams the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error. [#12](https://github.com/singer-io/tap-campaign-monitor/pull/12)
+- Bump to requests==2.34.2
+
 ## 1.2.0
 - Updated python version. [#11](https://github.com/singer-io/tap-campaign-monitor/pull/11)
 - Added integration tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.3.0
-- Streams the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error. [#12](https://github.com/singer-io/tap-campaign-monitor/pull/12)
+- Streams the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error. [#17](https://github.com/singer-io/tap-campaign-monitor/pull/17)
 - Bump to requests==2.34.2
 
 ## 1.2.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='tap-campaign-monitor',
-    version='1.2.0',
+    version='1.3.0',
     description=(
         'Singer.io tap for extracting data from the '
         'Campaign Monitor API'
@@ -14,7 +14,7 @@ setup(
     classifiers=['Programming Language :: Python :: 3 :: Only'],
     install_requires=[
         'singer-python==6.8.0',
-        'requests==2.33.1',
+        'requests==2.34.2',
         'backoff==2.2.1',
     ],
     extras_require={

--- a/tap_campaign_monitor/__init__.py
+++ b/tap_campaign_monitor/__init__.py
@@ -8,6 +8,7 @@ import singer
 
 
 from tap_campaign_monitor.client import CampaignMonitorClient
+from tap_campaign_monitor.discover import discover
 from tap_campaign_monitor.state import save_state
 from tap_campaign_monitor.streams import AVAILABLE_STREAMS
 from tap_campaign_monitor.streams.base import is_stream_selected
@@ -17,14 +18,8 @@ LOGGER = singer.get_logger()  # noqa
 
 def do_discover(args):
     LOGGER.info("Starting discovery.")
-
-    catalog = []
-
-    for available_stream in AVAILABLE_STREAMS:
-        stream = available_stream(args.config, args.state, None, None)
-
-        catalog += stream.generate_catalog()
-
+    client = CampaignMonitorClient(args.config)
+    catalog = discover(args.config, args.state, client)
     json.dump({'streams': catalog}, sys.stdout, indent=4)
 
 

--- a/tap_campaign_monitor/__init__.py
+++ b/tap_campaign_monitor/__init__.py
@@ -16,9 +16,19 @@ from tap_campaign_monitor.streams.base import is_stream_selected
 LOGGER = singer.get_logger()  # noqa
 
 
-def do_discover(args):
+def verify_credentials(config):
+    LOGGER.info("Verifying credentials.")
+    try:
+        client = CampaignMonitorClient(config)
+        LOGGER.info("Credentials verified successfully.")
+        return client
+    except Exception as e:
+        LOGGER.critical("Credential verification failed: %s", e)
+        raise
+
+
+def do_discover(args, client):
     LOGGER.info("Starting discovery.")
-    client = CampaignMonitorClient(args.config)
     catalog = discover(args.config, args.state, client)
     json.dump({'streams': catalog}, sys.stdout, indent=4)
 
@@ -63,10 +73,8 @@ def get_streams_to_replicate(config, state, catalog, client):
     return streams, campaign_substreams, list_substreams
 
 
-def do_sync(args):
+def do_sync(args, client):
     LOGGER.info("Starting sync.")
-
-    client = CampaignMonitorClient(args.config)
 
     state = args.state
 
@@ -104,10 +112,12 @@ def main():
     args = singer.utils.parse_args(
         required_config_keys=['client_id', 'refresh_token'])
 
+    client = verify_credentials(args.config)
+
     if args.discover:
-        do_discover(args)
+        do_discover(args, client)
     elif args.catalog:
-        do_sync(args)
+        do_sync(args, client)
 
 
 if __name__ == '__main__':

--- a/tap_campaign_monitor/client.py
+++ b/tap_campaign_monitor/client.py
@@ -98,7 +98,7 @@ class CampaignMonitorClient:
                 except (TypeError, ValueError):
                     self._retry_after = RETRY_RATE_LIMIT
                 raise Server429Error()
-            elif resp.status_code == 403:
+            elif resp.status_code in (401, 403):
                 raise CampaignMonitorForbiddenError(resp.text)
             elif resp.status_code != 200:
                 raise RuntimeError(resp.text)

--- a/tap_campaign_monitor/client.py
+++ b/tap_campaign_monitor/client.py
@@ -22,6 +22,10 @@ class Server429Error(Exception):
     pass
 
 
+class CampaignMonitorForbiddenError(Exception):
+    pass
+
+
 class CampaignMonitorClient:
 
     def __init__(self, config):
@@ -94,6 +98,8 @@ class CampaignMonitorClient:
                 except (TypeError, ValueError):
                     self._retry_after = RETRY_RATE_LIMIT
                 raise Server429Error()
+            elif resp.status_code == 403:
+                raise CampaignMonitorForbiddenError(resp.text)
             elif resp.status_code != 200:
                 raise RuntimeError(resp.text)
 

--- a/tap_campaign_monitor/client.py
+++ b/tap_campaign_monitor/client.py
@@ -40,7 +40,14 @@ class CampaignMonitorClient:
         url = "https://api.createsend.com/oauth/token"
         data = {'grant_type': 'refresh_token', 'refresh_token': self.config['refresh_token']}
         response = requests.request("POST", url, data=data)
-        return response.json()['access_token']
+        payload = response.json()
+        if 'access_token' not in payload:
+            raise CampaignMonitorForbiddenError(
+                "Invalid credentials: {}".format(
+                    payload.get('error_description') or payload.get('error') or response.text
+                )
+            )
+        return payload['access_token']
 
     def get_timezone(self):
         url = (

--- a/tap_campaign_monitor/discover.py
+++ b/tap_campaign_monitor/discover.py
@@ -9,15 +9,15 @@ from tap_campaign_monitor.streams import AVAILABLE_STREAMS
 LOGGER = singer.get_logger()
 
 
-def _get_inaccessible_tables(config, state, client):
+def _get_inaccessible_streams(config, state, client):
     """Return set of TABLE names for parent streams that return 403."""
-    inaccessible = set()
+    inaccessible_streams = set()
     for stream_cls in AVAILABLE_STREAMS:
         if not stream_cls.PARENT:
             stream = stream_cls(config, state, None, client)
             if not stream.check_access():
-                inaccessible.add(stream_cls.TABLE)
-    return inaccessible
+                inaccessible_streams.add(stream_cls.TABLE)
+    return inaccessible_streams
 
 
 def discover(config, state, client):
@@ -26,26 +26,26 @@ def discover(config, state, client):
     cannot access (HTTP 403). Raises CampaignMonitorForbiddenError if no
     parent stream is accessible.
     """
-    inaccessible = _get_inaccessible_tables(config, state, client)
+    inaccessible_streams = _get_inaccessible_streams(config, state, client)
 
-    parent_tables = {s.TABLE for s in AVAILABLE_STREAMS if not s.PARENT}
-    if not (parent_tables - inaccessible):
+    parent_streams = {s.TABLE for s in AVAILABLE_STREAMS if not s.PARENT}
+    if not (parent_streams - inaccessible_streams):
         raise CampaignMonitorForbiddenError(
             "HTTP-error-code: 403, Error: The credentials do not have "
             "'read' access to any supported streams."
         )
 
-    if inaccessible:
+    if inaccessible_streams:
         LOGGER.warning(
             "No 'read' access to stream(s): %s. Excluded from catalog.",
-            ", ".join(inaccessible),
+            ", ".join(inaccessible_streams),
         )
 
     catalog = []
     for stream_cls in AVAILABLE_STREAMS:
-        if stream_cls.TABLE in inaccessible:
+        if stream_cls.TABLE in inaccessible_streams:
             continue
-        if stream_cls.PARENT and stream_cls.PARENT in inaccessible:
+        if stream_cls.PARENT and stream_cls.PARENT in inaccessible_streams:
             LOGGER.warning(
                 "Stream '%s' excluded from catalog because its parent "
                 "stream '%s' is not accessible.",

--- a/tap_campaign_monitor/discover.py
+++ b/tap_campaign_monitor/discover.py
@@ -1,0 +1,57 @@
+import json
+import sys
+
+import singer
+
+from tap_campaign_monitor.client import CampaignMonitorForbiddenError
+from tap_campaign_monitor.streams import AVAILABLE_STREAMS
+
+LOGGER = singer.get_logger()
+
+
+def _get_inaccessible_tables(config, state, client):
+    """Return set of TABLE names for parent streams that return 403."""
+    inaccessible = set()
+    for stream_cls in AVAILABLE_STREAMS:
+        if not stream_cls.PARENT:
+            stream = stream_cls(config, state, None, client)
+            if not stream.check_access():
+                inaccessible.add(stream_cls.TABLE)
+    return inaccessible
+
+
+def discover(config, state, client):
+    """
+    Build and return the catalog list, excluding streams the credentials
+    cannot access (HTTP 403). Raises CampaignMonitorForbiddenError if no
+    parent stream is accessible.
+    """
+    inaccessible = _get_inaccessible_tables(config, state, client)
+
+    parent_tables = {s.TABLE for s in AVAILABLE_STREAMS if not s.PARENT}
+    if not (parent_tables - inaccessible):
+        raise CampaignMonitorForbiddenError(
+            "HTTP-error-code: 403, Error: The credentials do not have "
+            "'read' access to any supported streams."
+        )
+
+    if inaccessible:
+        LOGGER.warning(
+            "No 'read' access to stream(s): %s. Excluded from catalog.",
+            ", ".join(inaccessible),
+        )
+
+    catalog = []
+    for stream_cls in AVAILABLE_STREAMS:
+        if stream_cls.TABLE in inaccessible:
+            continue
+        if stream_cls.PARENT and stream_cls.PARENT in inaccessible:
+            LOGGER.warning(
+                "Stream '%s' excluded from catalog because its parent "
+                "stream '%s' is not accessible.",
+                stream_cls.TABLE, stream_cls.PARENT,
+            )
+            continue
+        catalog += stream_cls(config, state, None, None).generate_catalog()
+
+    return catalog

--- a/tap_campaign_monitor/discover.py
+++ b/tap_campaign_monitor/discover.py
@@ -1,5 +1,4 @@
 import json
-import sys
 
 import singer
 
@@ -10,7 +9,7 @@ LOGGER = singer.get_logger()
 
 
 def _get_inaccessible_streams(config, state, client):
-    """Return set of TABLE names for parent streams that return 403."""
+    """Return set of TABLE names for parent streams that return 401 or 403."""
     inaccessible_streams = set()
     for stream_cls in AVAILABLE_STREAMS:
         if not stream_cls.PARENT:
@@ -23,7 +22,7 @@ def _get_inaccessible_streams(config, state, client):
 def discover(config, state, client):
     """
     Build and return the catalog list, excluding streams the credentials
-    cannot access (HTTP 403). Raises CampaignMonitorForbiddenError if no
+    cannot access (HTTP 401/403). Raises CampaignMonitorForbiddenError if no
     parent stream is accessible.
     """
     inaccessible_streams = _get_inaccessible_streams(config, state, client)
@@ -31,7 +30,7 @@ def discover(config, state, client):
     parent_streams = {s.TABLE for s in AVAILABLE_STREAMS if not s.PARENT}
     if not (parent_streams - inaccessible_streams):
         raise CampaignMonitorForbiddenError(
-            "HTTP-error-code: 403, Error: The credentials do not have "
+            "HTTP-error-code: 401/403, Error: The credentials do not have "
             "'read' access to any supported streams."
         )
 

--- a/tap_campaign_monitor/streams/base.py
+++ b/tap_campaign_monitor/streams/base.py
@@ -100,7 +100,7 @@ class BaseStream:
     def check_access(self):
         """
         Verify that the API credentials have read access to this stream.
-        Returns True if accessible, False if a 403 Forbidden error is raised.
+        Returns True if accessible, False if a 401 or 403 error is raised.
         Child streams always return True (access is governed by the parent check).
         """
         from tap_campaign_monitor.client import CampaignMonitorForbiddenError

--- a/tap_campaign_monitor/streams/base.py
+++ b/tap_campaign_monitor/streams/base.py
@@ -97,6 +97,25 @@ class BaseStream:
         self.client = client
         self.substreams = []
 
+    def check_access(self):
+        """
+        Verify that the API credentials have read access to this stream.
+        Returns True if accessible, False if a 403 Forbidden error is raised.
+        Child streams always return True (access is governed by the parent check).
+        """
+        from tap_campaign_monitor.client import CampaignMonitorForbiddenError
+        if self.PARENT:
+            return True
+        url = 'https://api.createsend.com/api/v3.2{}'.format(self.api_path)
+        try:
+            self.client.make_request(url, self.API_METHOD)
+            return True
+        except CampaignMonitorForbiddenError as exc:
+            LOGGER.warning(
+                "Permission Error: Stream '%s' - %s",
+                self.__class__.__name__, exc)
+            return False
+
     def get_class_path(self):
         return os.path.dirname(inspect.getfile(self.__class__))
 

--- a/tests/mock_integration/base.py
+++ b/tests/mock_integration/base.py
@@ -454,6 +454,26 @@ class CampaignMonitorMockBaseTest:
 
         return mock_fn
 
+    @classmethod
+    def _create_forbidden_mock_client(cls, blocked_streams=()):
+        """Mock client that raises CampaignMonitorForbiddenError for
+        *blocked_streams* (parent stream TABLE names)."""
+        from tap_campaign_monitor.client import CampaignMonitorForbiddenError
+        normal_fn = cls._mock_make_request()
+
+        def mock_fn(url, method, params=None, body=None):
+            stream_name = cls._match_stream(url)
+            if stream_name in blocked_streams:
+                raise CampaignMonitorForbiddenError(
+                    '{"Code": 401, "Message": "Unauthorized"}')
+            return normal_fn(url, method, params=params, body=body)
+
+        client = MagicMock()
+        client.timezone = pytz.UTC
+        client.config = dict(cls.default_config)
+        client.make_request = MagicMock(side_effect=mock_fn)
+        return client
+
     # ---- Date-filtering mock client ---- #
 
     @classmethod

--- a/tests/mock_integration/test_discovery.py
+++ b/tests/mock_integration/test_discovery.py
@@ -1,6 +1,9 @@
 """Integration test: discovery produces correct catalog and metadata."""
 import unittest
 
+from tap_campaign_monitor.client import CampaignMonitorForbiddenError
+from tap_campaign_monitor.discover import discover
+
 from .base import CampaignMonitorMockBaseTest
 
 
@@ -69,3 +72,50 @@ class DiscoveryIntegrationTest(CampaignMonitorMockBaseTest, unittest.TestCase):
                                 'available',
                                 f"{field_name} should be available",
                             )
+
+
+class DiscoveryExclusionIntegrationTest(CampaignMonitorMockBaseTest, unittest.TestCase):
+    """Integration tests: unauthorized streams are excluded from catalog."""
+
+    def _run_discover_with_client(self, client):
+        return discover(self.default_config, {}, client)
+
+    def test_all_streams_present_when_all_accessible(self):
+        """Full catalog returned when no streams are blocked."""
+        client = self._create_mock_client()
+        entries = self._run_discover_with_client(client)
+        stream_ids = {e['tap_stream_id'] for e in entries}
+        self.assertEqual(stream_ids, self.ALL_STREAM_IDS)
+
+    def test_campaigns_and_children_excluded_when_403(self):
+        """campaigns + campaign_* excluded when campaigns returns 403."""
+        client = self._create_forbidden_mock_client(blocked_streams={'campaigns'})
+        entries = self._run_discover_with_client(client)
+        stream_ids = {e['tap_stream_id'] for e in entries}
+        campaign_streams = {s for s in self.ALL_STREAM_IDS
+                            if s == 'campaigns' or s.startswith('campaign_')}
+        self.assertTrue(campaign_streams.isdisjoint(stream_ids),
+                        f"Unexpected campaign streams in catalog: {campaign_streams & stream_ids}")
+        lists_streams = {s for s in self.ALL_STREAM_IDS
+                         if s == 'lists' or s.startswith('list_')}
+        self.assertTrue(lists_streams.issubset(stream_ids))
+
+    def test_lists_and_children_excluded_when_403(self):
+        """lists + list_* excluded when lists returns 403."""
+        client = self._create_forbidden_mock_client(blocked_streams={'lists'})
+        entries = self._run_discover_with_client(client)
+        stream_ids = {e['tap_stream_id'] for e in entries}
+        list_streams = {s for s in self.ALL_STREAM_IDS
+                        if s == 'lists' or s.startswith('list_')}
+        self.assertTrue(list_streams.isdisjoint(stream_ids),
+                        f"Unexpected list streams in catalog: {list_streams & stream_ids}")
+        campaign_streams = {s for s in self.ALL_STREAM_IDS
+                            if s == 'campaigns' or s.startswith('campaign_')}
+        self.assertTrue(campaign_streams.issubset(stream_ids))
+
+    def test_all_parents_blocked_raises_forbidden_error(self):
+        """CampaignMonitorForbiddenError raised when all parents blocked."""
+        client = self._create_forbidden_mock_client(
+            blocked_streams={'campaigns', 'lists'})
+        with self.assertRaises(CampaignMonitorForbiddenError):
+            self._run_discover_with_client(client)

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -124,10 +124,28 @@ class TestMakeRequest(unittest.TestCase):
     def test_non_200_raises_runtime_error(self, mock_request):
         """Test that non-200 non-retryable status raises RuntimeError."""
         client = self._make_client()
-        mock_request.return_value = MockResponse(401, {}, 'Unauthorized')
+        mock_request.return_value = MockResponse(404, {}, 'Not Found')
         with self.assertRaises(RuntimeError) as ctx:
             client.make_request('https://api.example.com/test', 'GET')
-        self.assertIn('Unauthorized', str(ctx.exception))
+        self.assertIn('Not Found', str(ctx.exception))
+
+    @patch('tap_campaign_monitor.client.requests.request')
+    def test_401_raises_forbidden_error(self, mock_request):
+        """Test that 401 raises CampaignMonitorForbiddenError."""
+        from tap_campaign_monitor.client import CampaignMonitorForbiddenError
+        client = self._make_client()
+        mock_request.return_value = MockResponse(401, {}, 'Unauthorized')
+        with self.assertRaises(CampaignMonitorForbiddenError):
+            client.make_request('https://api.example.com/test', 'GET')
+
+    @patch('tap_campaign_monitor.client.requests.request')
+    def test_403_raises_forbidden_error(self, mock_request):
+        """Test that 403 raises CampaignMonitorForbiddenError."""
+        from tap_campaign_monitor.client import CampaignMonitorForbiddenError
+        client = self._make_client()
+        mock_request.return_value = MockResponse(403, {}, 'Forbidden')
+        with self.assertRaises(CampaignMonitorForbiddenError):
+            client.make_request('https://api.example.com/test', 'GET')
 
     @patch('tap_campaign_monitor.client.requests.request')
     def test_request_with_params_and_body(self, mock_request):

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -55,28 +55,23 @@ class TestCheckAccess(unittest.TestCase):
 class TestDiscovery(unittest.TestCase):
     """Unit tests for do_discover access control."""
 
-    def _run_discover(self, args):
+    def _run_discover(self, args, client):
         from tap_campaign_monitor import do_discover
         with patch('sys.stdout', new_callable=StringIO) as mock_stdout:
-            do_discover(args)
+            do_discover(args, client)
             return json.loads(mock_stdout.getvalue())
 
-    @patch('tap_campaign_monitor.discover.CampaignMonitorForbiddenError', CampaignMonitorForbiddenError)
-    @patch('tap_campaign_monitor.CampaignMonitorClient')
-    def test_all_streams_accessible_returns_full_catalog(self, mock_client_cls):
+    def test_all_streams_accessible_returns_full_catalog(self):
         """All streams returned when all parent streams are accessible."""
-        mock_client_cls.return_value = _mock_client()
-        args = _make_args()
-        catalog = self._run_discover(args)
+        client = _mock_client()
+        catalog = self._run_discover(_make_args(), client)
         stream_names = {s['stream'] for s in catalog['streams']}
         self.assertIn('campaigns', stream_names)
         self.assertIn('lists', stream_names)
         self.assertIn('campaign_bounces', stream_names)
         self.assertIn('list_active_subscribers', stream_names)
 
-    @patch('tap_campaign_monitor.discover.CampaignMonitorForbiddenError', CampaignMonitorForbiddenError)
-    @patch('tap_campaign_monitor.CampaignMonitorClient')
-    def test_inaccessible_parent_excluded_from_catalog(self, mock_client_cls):
+    def test_inaccessible_parent_excluded_from_catalog(self):
         """campaigns and its children are excluded when campaigns returns 403."""
         client = _mock_client()
 
@@ -85,30 +80,22 @@ class TestDiscovery(unittest.TestCase):
                 raise CampaignMonitorForbiddenError("Forbidden")
 
         client.make_request.side_effect = make_request_side_effect
-        mock_client_cls.return_value = client
-        args = _make_args()
-        catalog = self._run_discover(args)
+        catalog = self._run_discover(_make_args(), client)
         stream_names = {s['stream'] for s in catalog['streams']}
         self.assertNotIn('campaigns', stream_names)
         self.assertNotIn('campaign_bounces', stream_names)
         self.assertIn('lists', stream_names)
         self.assertIn('list_active_subscribers', stream_names)
 
-    @patch('tap_campaign_monitor.discover.CampaignMonitorForbiddenError', CampaignMonitorForbiddenError)
-    @patch('tap_campaign_monitor.CampaignMonitorClient')
-    def test_all_parents_inaccessible_raises_error(self, mock_client_cls):
+    def test_all_parents_inaccessible_raises_error(self):
         """Raises CampaignMonitorForbiddenError when no parent stream is accessible."""
+        from tap_campaign_monitor import do_discover
         client = _mock_client()
         client.make_request.side_effect = CampaignMonitorForbiddenError("Forbidden")
-        mock_client_cls.return_value = client
-        args = _make_args()
-        from tap_campaign_monitor import do_discover
         with self.assertRaises(CampaignMonitorForbiddenError):
-            do_discover(args)
+            do_discover(_make_args(), client)
 
-    @patch('tap_campaign_monitor.discover.CampaignMonitorForbiddenError', CampaignMonitorForbiddenError)
-    @patch('tap_campaign_monitor.CampaignMonitorClient')
-    def test_child_excluded_when_parent_excluded(self, mock_client_cls):
+    def test_child_excluded_when_parent_excluded(self):
         """Child streams are excluded when parent is inaccessible."""
         client = _mock_client()
 
@@ -117,9 +104,7 @@ class TestDiscovery(unittest.TestCase):
                 raise CampaignMonitorForbiddenError("Forbidden")
 
         client.make_request.side_effect = make_request_side_effect
-        mock_client_cls.return_value = client
-        args = _make_args()
-        catalog = self._run_discover(args)
+        catalog = self._run_discover(_make_args(), client)
         stream_names = {s['stream'] for s in catalog['streams']}
         self.assertNotIn('lists', stream_names)
         self.assertNotIn('list_active_subscribers', stream_names)

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -44,10 +44,17 @@ class TestCheckAccess(unittest.TestCase):
         self.assertTrue(stream.check_access())
         client.make_request.assert_called_once()
 
-    def test_parent_stream_forbidden(self):
+    def test_parent_stream_forbidden_403(self):
         """Parent stream returns False when 403 is raised."""
         client = _mock_client()
         client.make_request.side_effect = CampaignMonitorForbiddenError("Forbidden")
+        stream = CampaignsStream(CONFIG, STATE, None, client)
+        self.assertFalse(stream.check_access())
+
+    def test_parent_stream_forbidden_401(self):
+        """Parent stream returns False when 401 (Unauthorized) is raised."""
+        client = _mock_client()
+        client.make_request.side_effect = CampaignMonitorForbiddenError("Unauthorized")
         stream = CampaignsStream(CONFIG, STATE, None, client)
         self.assertFalse(stream.check_access())
 

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,0 +1,132 @@
+import json
+import unittest
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+from tap_campaign_monitor.client import CampaignMonitorForbiddenError
+from tap_campaign_monitor.streams.campaigns import CampaignsStream
+from tap_campaign_monitor.streams.lists import ListsStream
+from tap_campaign_monitor.streams.campaign_bounces import CampaignBouncesStream
+from tap_campaign_monitor.streams.list_active_subscribers import ListActiveSubscribersStream
+
+
+CONFIG = {'client_id': 'test_client', 'refresh_token': 'test_token'}
+STATE = {}
+
+
+def _make_args(config=CONFIG, state=STATE):
+    args = MagicMock()
+    args.config = config
+    args.state = state
+    return args
+
+
+def _mock_client():
+    client = MagicMock()
+    client.config = CONFIG
+    return client
+
+
+class TestCheckAccess(unittest.TestCase):
+    """Unit tests for BaseStream.check_access()."""
+
+    def test_child_stream_always_returns_true(self):
+        """Child streams bypass access check and return True."""
+        client = _mock_client()
+        stream = CampaignBouncesStream(CONFIG, STATE, None, client)
+        self.assertTrue(stream.check_access())
+        client.make_request.assert_not_called()
+
+    def test_parent_stream_accessible(self):
+        """Parent stream returns True when API call succeeds."""
+        client = _mock_client()
+        stream = CampaignsStream(CONFIG, STATE, None, client)
+        self.assertTrue(stream.check_access())
+        client.make_request.assert_called_once()
+
+    def test_parent_stream_forbidden(self):
+        """Parent stream returns False when 403 is raised."""
+        client = _mock_client()
+        client.make_request.side_effect = CampaignMonitorForbiddenError("Forbidden")
+        stream = CampaignsStream(CONFIG, STATE, None, client)
+        self.assertFalse(stream.check_access())
+
+
+class TestDiscovery(unittest.TestCase):
+    """Unit tests for do_discover access control."""
+
+    def _run_discover(self, args):
+        from tap_campaign_monitor import do_discover
+        with patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+            do_discover(args)
+            return json.loads(mock_stdout.getvalue())
+
+    @patch('tap_campaign_monitor.discover.CampaignMonitorForbiddenError', CampaignMonitorForbiddenError)
+    @patch('tap_campaign_monitor.CampaignMonitorClient')
+    def test_all_streams_accessible_returns_full_catalog(self, mock_client_cls):
+        """All streams returned when all parent streams are accessible."""
+        mock_client_cls.return_value = _mock_client()
+        args = _make_args()
+        catalog = self._run_discover(args)
+        stream_names = {s['stream'] for s in catalog['streams']}
+        self.assertIn('campaigns', stream_names)
+        self.assertIn('lists', stream_names)
+        self.assertIn('campaign_bounces', stream_names)
+        self.assertIn('list_active_subscribers', stream_names)
+
+    @patch('tap_campaign_monitor.discover.CampaignMonitorForbiddenError', CampaignMonitorForbiddenError)
+    @patch('tap_campaign_monitor.CampaignMonitorClient')
+    def test_inaccessible_parent_excluded_from_catalog(self, mock_client_cls):
+        """campaigns and its children are excluded when campaigns returns 403."""
+        client = _mock_client()
+
+        def make_request_side_effect(url, method, *args, **kwargs):
+            if '/campaigns' in url:
+                raise CampaignMonitorForbiddenError("Forbidden")
+
+        client.make_request.side_effect = make_request_side_effect
+        mock_client_cls.return_value = client
+        args = _make_args()
+        catalog = self._run_discover(args)
+        stream_names = {s['stream'] for s in catalog['streams']}
+        self.assertNotIn('campaigns', stream_names)
+        self.assertNotIn('campaign_bounces', stream_names)
+        self.assertIn('lists', stream_names)
+        self.assertIn('list_active_subscribers', stream_names)
+
+    @patch('tap_campaign_monitor.discover.CampaignMonitorForbiddenError', CampaignMonitorForbiddenError)
+    @patch('tap_campaign_monitor.CampaignMonitorClient')
+    def test_all_parents_inaccessible_raises_error(self, mock_client_cls):
+        """Raises CampaignMonitorForbiddenError when no parent stream is accessible."""
+        client = _mock_client()
+        client.make_request.side_effect = CampaignMonitorForbiddenError("Forbidden")
+        mock_client_cls.return_value = client
+        args = _make_args()
+        from tap_campaign_monitor import do_discover
+        with self.assertRaises(CampaignMonitorForbiddenError):
+            do_discover(args)
+
+    @patch('tap_campaign_monitor.discover.CampaignMonitorForbiddenError', CampaignMonitorForbiddenError)
+    @patch('tap_campaign_monitor.CampaignMonitorClient')
+    def test_child_excluded_when_parent_excluded(self, mock_client_cls):
+        """Child streams are excluded when parent is inaccessible."""
+        client = _mock_client()
+
+        def make_request_side_effect(url, method, *args, **kwargs):
+            if '/lists' in url:
+                raise CampaignMonitorForbiddenError("Forbidden")
+
+        client.make_request.side_effect = make_request_side_effect
+        mock_client_cls.return_value = client
+        args = _make_args()
+        catalog = self._run_discover(args)
+        stream_names = {s['stream'] for s in catalog['streams']}
+        self.assertNotIn('lists', stream_names)
+        self.assertNotIn('list_active_subscribers', stream_names)
+        self.assertNotIn('list_bounced_subscribers', stream_names)
+        self.assertIn('campaigns', stream_names)
+        self.assertIn('campaign_bounces', stream_names)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description of change
Ticket: https://qlik-dev.atlassian.net/browse/SAC-30995
- Exclude unauthorized streams from catalog during discovery  


# Manual QA steps
 - [ ]  Discovery: Creds expired
 - [ ]  Sync: Creds expired
 - [x]  Unit Tests: Passes
 - [x]  Integration test: Mock passes
 
# Rollback steps
 - revert this branch